### PR TITLE
Removes auto-generated header template

### DIFF
--- a/src/test/java/ttt/BoardTest.java
+++ b/src/test/java/ttt/BoardTest.java
@@ -7,9 +7,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static ttt.PlayerSymbol.*;
 
-/**
- * Created by Georgina on 09/10/15.
- */
 public class BoardTest {
 
     @Test


### PR DESCRIPTION
Going forwards the header block will not be auto-generated as the template in IntelliJ has been updated to stop printing the author and date. This PR removes the last auto-generated instance. 
