### PR TITLE
4x4

### DIFF
--- a/src/main/java/ttt/Game.java
+++ b/src/main/java/ttt/Game.java
@@ -1,6 +1,7 @@
 package ttt;
 
 import ttt.board.Board;
+import ttt.board.BoardFactory;
 import ttt.player.Player;
 import ttt.player.PlayerFactory;
 import ttt.ui.CommandPrompt;
@@ -15,17 +16,18 @@ public class Game {
     private static final int PLAYER_ONE_INDEX = 0;
     private static final int PLAYER_TWO_INDEX = 1;
     private final PlayerFactory playerFactory;
+    private final BoardFactory boardFactory;
     private Board board;
     private Prompt gamePrompt;
 
-    public Game(Board board, Prompt gamePrompt, PlayerFactory playerFactory) {
-        this.board = board;
+    public Game(BoardFactory boardFactory, Prompt gamePrompt, PlayerFactory playerFactory) {
+        this.boardFactory = boardFactory;
         this.gamePrompt = gamePrompt;
         this.playerFactory = playerFactory;
     }
 
     public static void main(String... args) {
-        Game game = new Game(new Board(), buildPrompt(), new PlayerFactory());
+        Game game = new Game(new BoardFactory(), buildPrompt(), new PlayerFactory());
 
         game.play();
     }
@@ -34,7 +36,6 @@ public class Game {
         ReplayOption replayOption = Y;
         while (replayOption.equals(Y)) {
             replayOption = playSingleGame();
-            reinitialiseBoard();
         }
     }
 
@@ -42,6 +43,8 @@ public class Game {
         int currentPlayerIndex = PLAYER_ONE_INDEX;
         boolean hasWinner = false;
 
+        int dimension = gamePrompt.getBoardDimension();
+        board = boardFactory.createBoardWithSize(dimension);
         Player[] players = createPlayers();
 
         while (gameInProgress(hasWinner)) {
@@ -70,10 +73,6 @@ public class Game {
 
     private int toggle(int currentPlayerIndex) {
         return currentPlayerIndex == PLAYER_ONE_INDEX ? PLAYER_TWO_INDEX : PLAYER_ONE_INDEX;
-    }
-
-    private void reinitialiseBoard() {
-        board = new Board();
     }
 
     private void displayResultsOfGame(boolean hasWinner) {

--- a/src/main/java/ttt/Game.java
+++ b/src/main/java/ttt/Game.java
@@ -43,9 +43,10 @@ public class Game {
         int currentPlayerIndex = PLAYER_ONE_INDEX;
         boolean hasWinner = false;
 
-        int dimension = gamePrompt.getBoardDimension();
+        GameType gameType = gamePrompt.getGameType();
+        int dimension = gamePrompt.getBoardDimension(gameType);
         board = boardFactory.createBoardWithSize(dimension);
-        Player[] players = createPlayers();
+        Player[] players = createPlayersFor(gameType, dimension);
 
         while (gameInProgress(hasWinner)) {
             updateBoardWithPlayersMove(players[currentPlayerIndex]);
@@ -57,9 +58,8 @@ public class Game {
         return gamePrompt.getReplayOption();
     }
 
-    private Player[] createPlayers() {
-        GameType playerOption = gamePrompt.getGameType();
-        return playerFactory.createPlayers(playerOption, gamePrompt);
+    private Player[] createPlayersFor(GameType gameType, int dimension) {
+        return playerFactory.createPlayers(gameType, gamePrompt, dimension);
     }
 
     private boolean gameInProgress(boolean hasWinner) {

--- a/src/main/java/ttt/GameType.java
+++ b/src/main/java/ttt/GameType.java
@@ -1,17 +1,18 @@
 package ttt;
 
 public enum GameType {
-    HUMAN_VS_HUMAN(1, "Human vs Human"),
-    HUMAN_VS_UNBEATABLE(2, "Human vs Unbeatable"),
-    UNBEATABLE_VS_HUMAN(3, "Unbeatable vs Human");
-
+    HUMAN_VS_HUMAN("Human vs Human", 1, 10),
+    HUMAN_VS_UNBEATABLE("Human vs Unbeatable", 2, 4),
+    UNBEATABLE_VS_HUMAN("Unbeatable vs Human", 3, 4);
 
     private final int gameType;
+    private final int maximumDimension;
     private final String gameName;
 
-    GameType(int gameType, String gameName) {
-        this.gameType = gameType;
+    GameType(String gameName, int gameType, int maximumDimension) {
         this.gameName = gameName;
+        this.gameType = gameType;
+        this.maximumDimension = maximumDimension;
     }
 
     public int numericRepresentation() {
@@ -22,6 +23,14 @@ public enum GameType {
         return gameName;
     }
 
+
+    public int dimensionLowerBoundary() {
+        return 1;
+    }
+
+    public int dimensionUpperBoundary() {
+        return maximumDimension;
+    }
 
     public static GameType of(int numericRepresentation) {
         for(GameType gameType : GameType.values()) {

--- a/src/main/java/ttt/GameType.java
+++ b/src/main/java/ttt/GameType.java
@@ -5,18 +5,18 @@ public enum GameType {
     HUMAN_VS_UNBEATABLE("Human vs Unbeatable", 2, 4),
     UNBEATABLE_VS_HUMAN("Unbeatable vs Human", 3, 4);
 
-    private final int gameType;
+    private final int promptNumber;
     private final int maximumDimension;
     private final String gameName;
 
-    GameType(String gameName, int gameType, int maximumDimension) {
+    GameType(String gameName, int promptNumber, int maximumDimension) {
         this.gameName = gameName;
-        this.gameType = gameType;
+        this.promptNumber = promptNumber;
         this.maximumDimension = maximumDimension;
     }
 
     public int numericRepresentation() {
-        return gameType;
+        return promptNumber;
     }
 
     public String gameNameForDisplay() {

--- a/src/main/java/ttt/board/Board.java
+++ b/src/main/java/ttt/board/Board.java
@@ -8,21 +8,31 @@ import java.util.List;
 import static ttt.player.PlayerSymbol.VACANT;
 
 public class Board {
-    public static final int BOARD_DIMENSION = 3;
-    private static final int NUMBER_OF_SLOTS = BOARD_DIMENSION * BOARD_DIMENSION;
-    private PlayerSymbol[] grid = new PlayerSymbol[BOARD_DIMENSION * BOARD_DIMENSION];
-
-    public Board() {
-        this(VACANT, VACANT, VACANT, VACANT, VACANT, VACANT, VACANT, VACANT, VACANT);
-    }
+    public int dimension;
+    private int numberOfSlots;
+    private PlayerSymbol[] grid;
 
     public Board(PlayerSymbol... initialGridLayout) {
+        this.dimension = (int) Math.sqrt(initialGridLayout.length);
+        this.numberOfSlots = dimension * dimension;
         this.grid = initialGridLayout;
+    }
+
+    public Board(int dimension) {
+        this.dimension = dimension;
+        this.numberOfSlots = dimension * dimension;
+
+        PlayerSymbol[] initialisation = new PlayerSymbol[numberOfSlots];
+        for (int i = 0; i < numberOfSlots; i++) {
+            initialisation[i] = VACANT;
+        }
+
+        this.grid = initialisation;
     }
 
     public Line[] getRows() {
         LineGenerator lines = new LineGenerator(grid);
-        return new Line[]{lines.topRow(), lines.middleRow(), lines.bottomRow()};
+        return lines.getRows();
     }
 
     public boolean hasWinningCombination() {
@@ -47,7 +57,7 @@ public class Board {
     }
 
     public boolean hasFreeSpace() {
-        for (int cellIndex = 0; cellIndex < NUMBER_OF_SLOTS; cellIndex++) {
+        for (int cellIndex = 0; cellIndex < numberOfSlots; cellIndex++) {
             if (isVacantAt(cellIndex)) {
                 return true;
             }
@@ -60,7 +70,7 @@ public class Board {
     }
 
     public boolean isWithinGridBoundary(int index) {
-        return index >= 0 && index < NUMBER_OF_SLOTS;
+        return index >= 0 && index < numberOfSlots;
     }
 
     public boolean isVacantAt(int cellIndex) {
@@ -82,7 +92,7 @@ public class Board {
 
     public List<Integer> getVacantPositions() {
         List<Integer> freePositions = new ArrayList<>();
-        for (int i = 0; i < NUMBER_OF_SLOTS; i++) {
+        for (int i = 0; i < numberOfSlots; i++) {
             if (isVacantAt(i)) {
                 freePositions.add(i);
             }

--- a/src/main/java/ttt/board/Board.java
+++ b/src/main/java/ttt/board/Board.java
@@ -30,7 +30,7 @@ public class Board {
         this.grid = initialisation;
     }
 
-    public Line[] getRows() {
+    public List<Line> getRows() {
         LineGenerator lines = new LineGenerator(grid);
         return lines.getRows();
     }
@@ -77,7 +77,7 @@ public class Board {
         return grid[cellIndex] == VACANT;
     }
 
-    private boolean checkForWinIn(Line[] lines) {
+    private boolean checkForWinIn(List<Line> lines) {
         for (Line line : lines) {
             if (line.isWinning()) {
                 return true;

--- a/src/main/java/ttt/board/BoardFactory.java
+++ b/src/main/java/ttt/board/BoardFactory.java
@@ -1,0 +1,7 @@
+package ttt.board;
+
+public class BoardFactory {
+    public Board createBoardWithSize(int dimension) {
+        return new Board(dimension);
+    }
+}

--- a/src/main/java/ttt/board/Line.java
+++ b/src/main/java/ttt/board/Line.java
@@ -2,8 +2,6 @@ package ttt.board;
 
 import ttt.player.PlayerSymbol;
 
-import java.util.Arrays;
-
 import static ttt.player.PlayerSymbol.O;
 import static ttt.player.PlayerSymbol.X;
 
@@ -18,19 +16,17 @@ public class Line {
         return containsOnly(X) || containsOnly(O);
     }
 
-    private boolean containsOnly(PlayerSymbol symbol) {
-        return Arrays.equals(line, matching(symbol));
+    private boolean containsOnly(PlayerSymbol playerSymbol) {
+        boolean allMatching = true;
+        for(PlayerSymbol symbol : line) {
+            allMatching = allMatching && (symbol == playerSymbol);
+        }
+
+        return allMatching;
+
     }
 
     public PlayerSymbol[] getSymbols() {
         return line;
-    }
-
-    private PlayerSymbol[] matching(PlayerSymbol symbol) {
-        PlayerSymbol[] lineOfMatchingSymbols = new PlayerSymbol[line.length];
-        for(int i=0; i<line.length; i++) {
-            lineOfMatchingSymbols[i] = symbol;
-        }
-        return lineOfMatchingSymbols;
     }
 }

--- a/src/main/java/ttt/board/Line.java
+++ b/src/main/java/ttt/board/Line.java
@@ -19,10 +19,18 @@ public class Line {
     }
 
     private boolean containsOnly(PlayerSymbol symbol) {
-        return Arrays.equals(line, new PlayerSymbol[]{symbol, symbol, symbol});
+        return Arrays.equals(line, matching(symbol));
     }
 
     public PlayerSymbol[] getSymbols() {
         return line;
+    }
+
+    private PlayerSymbol[] matching(PlayerSymbol symbol) {
+        PlayerSymbol[] lineOfMatchingSymbols = new PlayerSymbol[line.length];
+        for(int i=0; i<line.length; i++) {
+            lineOfMatchingSymbols[i] = symbol;
+        }
+        return lineOfMatchingSymbols;
     }
 }

--- a/src/main/java/ttt/board/LineGenerator.java
+++ b/src/main/java/ttt/board/LineGenerator.java
@@ -13,22 +13,13 @@ public class LineGenerator {
 
     public Line[] linesForAllDirections() {
         Line[] allLines = new Line[(dimension * 2) + 2];
-
         Line[] rows = getRows();
-        for (int i = 0; i < rows.length; i++) {
-            allLines[i] = rows[i];
-        }
-
         Line[] columns = getColumns();
 
-        for (int i = 0; i < columns.length; i++) {
-            allLines[i + rows.length] = columns[i];
-        }
+        copyRows(allLines, rows);
+        copyColumns(allLines, rows.length, columns);
+        copyDiagonals(allLines, rows.length + columns.length);
 
-        int index = rows.length + columns.length;
-
-        allLines[index] = backslashDiagonal();
-        allLines[index + 1] = forwardslashDiagonal();
         return allLines;
     }
 
@@ -83,5 +74,22 @@ public class LineGenerator {
             offset += dimension + 1;
         }
         return new Line(symbols);
+    }
+
+    private void copyDiagonals(Line[] allLines, int startingIndex) {
+        allLines[startingIndex] = backslashDiagonal();
+        allLines[startingIndex + 1] = forwardslashDiagonal();
+    }
+
+    private void copyColumns(Line[] allLines, int startingIndex, Line[] columns) {
+        for (int i = 0; i < columns.length; i++) {
+            allLines[i + startingIndex] = columns[i];
+        }
+    }
+
+    private void copyRows(Line[] allLines, Line[] rows) {
+        for (int i = 0; i < rows.length; i++) {
+            allLines[i] = rows[i];
+        }
     }
 }

--- a/src/main/java/ttt/board/LineGenerator.java
+++ b/src/main/java/ttt/board/LineGenerator.java
@@ -4,46 +4,84 @@ import ttt.player.PlayerSymbol;
 
 public class LineGenerator {
     private final PlayerSymbol[] grid;
+    private int dimension;
 
     public LineGenerator(PlayerSymbol... grid) {
         this.grid = grid;
+        this.dimension = (int) Math.sqrt(grid.length);
     }
 
     public Line[] linesForAllDirections() {
-        return new Line[] {topRow(), middleRow(), bottomRow(),
-                leftColumn(), middleColumn(), rightColumn(),
-                backslashDiagonal(), forwardslashDiagonal()};
+        Line[] allLines = new Line[(dimension * 2) + 2];
+
+        Line[] rows = getRows();
+        for (int i = 0; i < rows.length; i++) {
+            allLines[i] = rows[i];
+        }
+
+        Line[] columns = getColumns();
+
+        for (int i = 0; i < columns.length; i++) {
+            allLines[i + rows.length] = columns[i];
+        }
+
+        int index = rows.length + columns.length;
+
+        allLines[index] = backslashDiagonal();
+        allLines[index + 1] = forwardslashDiagonal();
+        return allLines;
     }
 
-    public Line topRow() {
-        return new Line(grid[0], grid[1], grid[2]);
+    public Line[] getRows() {
+        Line[] horizontals = new Line[dimension];
+
+        int startingIndex = 0;
+        for (int rowNumber = 0; rowNumber < dimension; rowNumber++) {
+            PlayerSymbol[] symbols = new PlayerSymbol[dimension];
+            for (int i = 0; i < dimension; i++) {
+                symbols[i] = grid[i + startingIndex];
+            }
+            startingIndex += dimension;
+
+            horizontals[rowNumber] = new Line(symbols);
+        }
+        return horizontals;
     }
 
-    public Line middleRow() {
-        return new Line(grid[3], grid[4], grid[5]);
-    }
+    private Line[] getColumns() {
+        Line[] columns = new Line[dimension];
 
-    public Line bottomRow() {
-        return new Line(grid[6], grid[7], grid[8]);
-    }
+        for (int rowNumber = 0; rowNumber < dimension; rowNumber++) {
+            PlayerSymbol[] symbols = new PlayerSymbol[dimension];
+            int offset = rowNumber;
+            for (int i = 0; i < dimension; i++) {
+                symbols[i] = grid[offset];
+                offset += dimension;
+            }
 
-    private Line leftColumn() {
-        return new Line(grid[0], grid[3], grid[6]);
-    }
+            columns[rowNumber] = new Line(symbols);
+        }
 
-    private Line middleColumn() {
-        return new Line(grid[1], grid[4], grid[7]);
-    }
-
-    private Line rightColumn() {
-        return new Line(grid[2], grid[5], grid[8]);
+        return columns;
     }
 
     private Line forwardslashDiagonal() {
-        return new Line(grid[2], grid[4], grid[6]);
+        int offset = dimension - 1;
+        PlayerSymbol[] symbols = new PlayerSymbol[dimension];
+        for (int i = 0; i < dimension; i++) {
+            symbols[i] = grid[offset];
+            offset += dimension - 1;
+        }
+        return new Line(symbols);
     }
 
     private Line backslashDiagonal() {
-        return new Line(grid[0], grid[4], grid[8]);
+        PlayerSymbol[] symbols = new PlayerSymbol[dimension];
+        int offset = 0;
+        for (int i = 0; i < dimension; i++) {
+            symbols[i] = grid[offset];
+            offset += dimension + 1;
+        }
+        return new Line(symbols);
     }
 }

--- a/src/main/java/ttt/board/LineGenerator.java
+++ b/src/main/java/ttt/board/LineGenerator.java
@@ -2,6 +2,9 @@ package ttt.board;
 
 import ttt.player.PlayerSymbol;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class LineGenerator {
     private final PlayerSymbol[] grid;
     private int dimension;
@@ -11,20 +14,17 @@ public class LineGenerator {
         this.dimension = (int) Math.sqrt(grid.length);
     }
 
-    public Line[] linesForAllDirections() {
-        Line[] allLines = new Line[(dimension * 2) + 2];
-        Line[] rows = getRows();
-        Line[] columns = getColumns();
-
-        copyRows(allLines, rows);
-        copyColumns(allLines, rows.length, columns);
-        copyDiagonals(allLines, rows.length + columns.length);
+    public List<Line> linesForAllDirections() {
+        List<Line> allLines = new ArrayList<>();
+        allLines.addAll(getRows());
+        allLines.addAll(getColumns());
+        allLines.addAll(getDiagonals());
 
         return allLines;
     }
 
-    public Line[] getRows() {
-        Line[] horizontals = new Line[dimension];
+    public List<Line> getRows() {
+        List<Line> horizontals = new ArrayList<>();
 
         int startingIndex = 0;
         for (int rowNumber = 0; rowNumber < dimension; rowNumber++) {
@@ -34,13 +34,13 @@ public class LineGenerator {
             }
             startingIndex += dimension;
 
-            horizontals[rowNumber] = new Line(symbols);
+            horizontals.add(new Line(symbols));
         }
         return horizontals;
     }
 
-    private Line[] getColumns() {
-        Line[] columns = new Line[dimension];
+    private List<Line> getColumns() {
+        List<Line> columns = new ArrayList<>();
 
         for (int rowNumber = 0; rowNumber < dimension; rowNumber++) {
             PlayerSymbol[] symbols = new PlayerSymbol[dimension];
@@ -50,7 +50,7 @@ public class LineGenerator {
                 offset += dimension;
             }
 
-            columns[rowNumber] = new Line(symbols);
+            columns.add(new Line(symbols));
         }
 
         return columns;
@@ -76,20 +76,11 @@ public class LineGenerator {
         return new Line(symbols);
     }
 
-    private void copyDiagonals(Line[] allLines, int startingIndex) {
-        allLines[startingIndex] = backslashDiagonal();
-        allLines[startingIndex + 1] = forwardslashDiagonal();
-    }
+    private List<Line> getDiagonals() {
+        List<Line> diagonals = new ArrayList<>();
+        diagonals.add(backslashDiagonal());
+        diagonals.add(forwardslashDiagonal());
 
-    private void copyColumns(Line[] allLines, int startingIndex, Line[] columns) {
-        for (int i = 0; i < columns.length; i++) {
-            allLines[i + startingIndex] = columns[i];
-        }
-    }
-
-    private void copyRows(Line[] allLines, Line[] rows) {
-        for (int i = 0; i < rows.length; i++) {
-            allLines[i] = rows[i];
-        }
+        return diagonals;
     }
 }

--- a/src/main/java/ttt/inputvalidation/ReplayOptionValidator.java
+++ b/src/main/java/ttt/inputvalidation/ReplayOptionValidator.java
@@ -6,7 +6,7 @@ public class ReplayOptionValidator implements InputValidator {
     @Override
     public ValidationResult isValid(String input) {
         for (ReplayOption replayOption : ReplayOption.values()) {
-            if (replayOption.name().equals(input)) {
+            if (replayOption.name().equalsIgnoreCase(input)) {
                 return new ValidationResult(input, true, "");
             }
         }

--- a/src/main/java/ttt/inputvalidation/WithinGivenRangeValidator.java
+++ b/src/main/java/ttt/inputvalidation/WithinGivenRangeValidator.java
@@ -1,0 +1,20 @@
+package ttt.inputvalidation;
+
+public class WithinGivenRangeValidator implements InputValidator {
+    private int lowerBoundary = 1;
+    private int upperBoundary;
+
+    public WithinGivenRangeValidator(int upperBoundary) {
+        this.upperBoundary = upperBoundary;
+    }
+
+    @Override
+    public ValidationResult isValid(String input) {
+        Integer numericInput = Integer.valueOf(input);
+        if (numericInput <= upperBoundary
+                && numericInput >= lowerBoundary) {
+            return new ValidationResult(input, true, "");
+        }
+        return new ValidationResult(input, false, "[" + input + "] is outside of the range " + lowerBoundary + " to " + upperBoundary);
+    }
+}

--- a/src/main/java/ttt/player/DelayedUnbeatablePlayer.java
+++ b/src/main/java/ttt/player/DelayedUnbeatablePlayer.java
@@ -1,0 +1,24 @@
+package ttt.player;
+
+import ttt.board.Board;
+
+import java.util.List;
+
+public class DelayedUnbeatablePlayer extends Player {
+    private final UnbeatablePlayer unbeatablePlayer;
+
+    public DelayedUnbeatablePlayer(PlayerSymbol symbol, UnbeatablePlayer unbeatablePlayer) {
+        super(symbol);
+        this.unbeatablePlayer = unbeatablePlayer;
+    }
+
+    @Override
+    public int chooseNextMoveFrom(Board board) {
+        List<Integer> vacantPositions = board.getVacantPositions();
+
+        if (vacantPositions.size() < 12) {
+            return unbeatablePlayer.chooseNextMoveFrom(board);
+        }
+        return vacantPositions.get(0);
+    }
+}

--- a/src/main/java/ttt/player/PlayerFactory.java
+++ b/src/main/java/ttt/player/PlayerFactory.java
@@ -8,14 +8,15 @@ import static ttt.player.PlayerSymbol.O;
 import static ttt.player.PlayerSymbol.X;
 
 public class PlayerFactory {
+    private static final int THREE = 3;
 
-    public Player[] createPlayers(GameType playerOption, Prompt prompt) {
+    public Player[] createPlayers(GameType playerOption, Prompt prompt, int dimension) {
         if (HUMAN_VS_HUMAN == playerOption) {
             return humanVsHuman(prompt);
         } else if (HUMAN_VS_UNBEATABLE == playerOption) {
-            return humanVsUnbeatable(prompt);
+            return humanVsUnbeatable(prompt, dimension);
         } else if (UNBEATABLE_VS_HUMAN == playerOption) {
-            return unbeatableVsHuman(prompt);
+            return unbeatableVsHuman(prompt, dimension);
         }
         return humanVsHuman(prompt);
     }
@@ -24,11 +25,18 @@ public class PlayerFactory {
         return new Player[]{new HumanPlayer(X, prompt), new HumanPlayer(O, prompt)};
     }
 
-    private Player[] humanVsUnbeatable(Prompt prompt) {
-        return new Player[]{new HumanPlayer(X, prompt), new UnbeatablePlayer(O)};
+    private Player[] humanVsUnbeatable(Prompt prompt, int dimension) {
+        return new Player[]{new HumanPlayer(X, prompt),
+                getUnbeatablePlayerFor(O, dimension)};
     }
 
-    private Player[] unbeatableVsHuman(Prompt prompt) {
-        return new Player[]{new UnbeatablePlayer(X), new HumanPlayer(O, prompt)};
+    private Player[] unbeatableVsHuman(Prompt prompt, int dimension) {
+        return new Player[]{getUnbeatablePlayerFor(X, dimension), new HumanPlayer(O, prompt)};
+    }
+
+    private Player getUnbeatablePlayerFor(PlayerSymbol symbol, int dimension) {
+        return dimension <= THREE
+                ? new UnbeatablePlayer(symbol)
+                : new DelayedUnbeatablePlayer(symbol, new UnbeatablePlayer(X));
     }
 }

--- a/src/main/java/ttt/player/UnbeatablePlayer.java
+++ b/src/main/java/ttt/player/UnbeatablePlayer.java
@@ -12,9 +12,6 @@ public class UnbeatablePlayer extends Player {
     private static final int BETA = 100;
     private static final int MAX_PLAYER_INITIAL_SCORE = -100;
     private static final int MIN_PLAYER_INITIAL_SCORE = 100;
-    private static final int MAX_PLAYER_WIN_SCORE = 10;
-    private static final int MIN_PLAYER_WIN_SCORE = -10;
-    private static final int DRAW_SCORE = 0;
 
     public UnbeatablePlayer(PlayerSymbol symbol) {
         super(symbol);
@@ -29,7 +26,6 @@ public class UnbeatablePlayer extends Player {
                 true,
                 ALPHA,
                 BETA);
-
         return bestMove.getMove();
     }
 
@@ -66,11 +62,11 @@ public class UnbeatablePlayer extends Player {
 
     private ValuedPosition score(Board board, int remainingDepth) {
         if (board.getWinningSymbol() == getSymbol()) {
-            return new ValuedPosition(MAX_PLAYER_WIN_SCORE + remainingDepth);
+            return new MaxPlayerWin(remainingDepth);
         } else if (board.getWinningSymbol() == opponent(getSymbol())) {
-            return new ValuedPosition(MIN_PLAYER_WIN_SCORE - remainingDepth);
+            return new MinPlayerWin(remainingDepth);
         }
-        return new ValuedPosition(DRAW_SCORE);
+        return new Draw();
     }
 
     private void revertMove(Board board, int vacantPosition) {
@@ -143,6 +139,30 @@ public class UnbeatablePlayer extends Player {
 
         public int getMove() {
             return move;
+        }
+    }
+
+    private static class Draw extends ValuedPosition {
+        private static final int DRAW_SCORE = 0;
+
+        public Draw() {
+            super(DRAW_SCORE);
+        }
+    }
+
+    private static class MaxPlayerWin extends ValuedPosition {
+        private static final int MAX_PLAYER_WIN_SCORE = 10;
+
+        public MaxPlayerWin(int depth) {
+            super(MAX_PLAYER_WIN_SCORE + depth);
+        }
+    }
+
+    private static class MinPlayerWin extends ValuedPosition {
+        private static final int MIN_PLAYER_WIN_SCORE = -10;
+
+        public MinPlayerWin(int depth) {
+            super(MIN_PLAYER_WIN_SCORE - depth);
         }
     }
 }

--- a/src/main/java/ttt/ui/CommandPrompt.java
+++ b/src/main/java/ttt/ui/CommandPrompt.java
@@ -73,8 +73,8 @@ public class CommandPrompt implements Prompt {
     public void print(Board board) {
         String boardForDisplay = BOARD_COLOUR_ANSII_CHARACTERS + newLine();
 
-        Line[] rows = board.getRows();
-        int dimension = rows.length;
+        List<Line> rows = board.getRows();
+        int dimension = rows.size();
         int offset = 0;
         for (Line row : rows) {
             for (PlayerSymbol symbol : row.getSymbols()) {

--- a/src/main/java/ttt/ui/Prompt.java
+++ b/src/main/java/ttt/ui/Prompt.java
@@ -6,6 +6,7 @@ import ttt.board.Board;
 import ttt.player.PlayerSymbol;
 
 public interface Prompt {
+    int getBoardDimension();
     GameType getGameType();
     ReplayOption getReplayOption();
     int getNextMove(Board board);

--- a/src/main/java/ttt/ui/Prompt.java
+++ b/src/main/java/ttt/ui/Prompt.java
@@ -6,7 +6,7 @@ import ttt.board.Board;
 import ttt.player.PlayerSymbol;
 
 public interface Prompt {
-    int getBoardDimension();
+    int getBoardDimension(GameType gameType);
     GameType getGameType();
     ReplayOption getReplayOption();
     int getNextMove(Board board);

--- a/src/test/java/ttt/BoardFactoryStub.java
+++ b/src/test/java/ttt/BoardFactoryStub.java
@@ -1,0 +1,23 @@
+package ttt;
+
+import ttt.board.Board;
+import ttt.board.BoardFactory;
+
+public class BoardFactoryStub extends BoardFactory {
+    private final Board[] boards;
+    private int boardIndex = 0;
+    private int dimension;
+
+    public BoardFactoryStub(Board... boardsToReturn) {
+        this.boards = boardsToReturn;
+    }
+
+    public Board createBoardWithSize(int dimension) {
+        this.dimension = dimension;
+        return boards[boardIndex++];
+    }
+
+    public int getDimension() {
+        return dimension;
+    }
+}

--- a/src/test/java/ttt/GameTest.java
+++ b/src/test/java/ttt/GameTest.java
@@ -23,7 +23,7 @@ public class GameTest {
 
     @Test
     public void promptsForBoardDimension() {
-        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(HUMAN_VS_HUMAN + DIMENSION + DO_NOT_REPLAY));
         BoardFactoryStub boardFactoryStub = new BoardFactoryStub(new Board(3));
 
         Game game = new Game(boardFactoryStub, gamePrompt, new PlayerFactoryStub(
@@ -61,7 +61,7 @@ public class GameTest {
         );
 
         Game game = new Game(new BoardFactoryStub(new Board(3)),
-                createCommandPromptToReadInput(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY),
+                createCommandPromptToReadInput(HUMAN_VS_HUMAN + DIMENSION + DO_NOT_REPLAY),
                 playerFactoryStub);
 
         game.play();
@@ -72,7 +72,7 @@ public class GameTest {
 
     @Test
     public void printsCongratulatoryMessageWhenThereIsAWinningFormation() {
-        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(HUMAN_VS_HUMAN + DIMENSION + DO_NOT_REPLAY));
 
         PlayerFactoryStub playerFactorySpy = new PlayerFactoryStub(
                 createHumanPlayer(X, createCommandPromptToReadInput("1\n2\n3\n")),
@@ -93,7 +93,7 @@ public class GameTest {
     @Test
     public void printsDrawMessageWhenThereAreNoMoreSpacesOnTheBoardAndNoWinner() {
         Board board = new Board(X, O, O, O, X, X, VACANT, VACANT, O);
-        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(HUMAN_VS_HUMAN + DIMENSION + DO_NOT_REPLAY));
 
         PlayerFactoryStub playerFactoryStub = new PlayerFactoryStub(
                 createHumanPlayer(X, createCommandPromptToReadInput("8\n")),
@@ -114,7 +114,7 @@ public class GameTest {
     @Test
     public void printsTheFinalStateOfTheBoard() {
         Board board = new Board(X, VACANT, X, O, X, O, O, O, X);
-        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(HUMAN_VS_HUMAN + DIMENSION + DO_NOT_REPLAY));
 
         PlayerFactoryStub playerFactoryStub = new PlayerFactoryStub(
                 createHumanPlayer(X, createCommandPromptToReadInput("2\n")),
@@ -131,7 +131,7 @@ public class GameTest {
     @Test
     public void promptsToPlayAgain() {
         Board board = new Board(X, VACANT, X, O, X, O, O, O, X);
-        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + REPLAY + DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(HUMAN_VS_HUMAN + DIMENSION + REPLAY +  HUMAN_VS_HUMAN + DIMENSION + DO_NOT_REPLAY));
 
         PlayerFactoryStub playerFactoryStub = new PlayerFactoryStub(
                 createHumanPlayer(X, createCommandPromptToReadInput("2\n2\n3\n5\n")),

--- a/src/test/java/ttt/GameTest.java
+++ b/src/test/java/ttt/GameTest.java
@@ -16,11 +16,32 @@ import static ttt.player.PlayerSymbol.*;
 
 public class GameTest {
 
+    public static final String DIMENSION = "3\n";
+    public static final String HUMAN_VS_HUMAN = "1\n";
+    public static final String DO_NOT_REPLAY = "N\n";
+    public static final String REPLAY = "Y\n";
+
+    @Test
+    public void promptsForBoardDimension() {
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
+        BoardFactoryStub boardFactoryStub = new BoardFactoryStub(new Board(3));
+
+        Game game = new Game(boardFactoryStub, gamePrompt, new PlayerFactoryStub(
+                new PlayerSpy(X, createCommandPromptToReadInput("1\n5\n6\n7\n8\n")),
+                new PlayerSpy(O, createCommandPromptToReadInput("2\n3\n4\n9\n")))
+        );
+
+        game.play();
+
+        assertThat(gamePrompt.getNumberOfTimesBoardDimensionPrompted(), is(1));
+        assertThat(boardFactoryStub.getDimension(), is(3));
+    }
+
     @Test
     public void printsChoiceOfPlayers() {
-        PromptSpy gamePrompt = new PromptSpy(new StringReader("1\nN\n"));
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
 
-        Game game = new Game(new Board(), gamePrompt, new PlayerFactorySpy(
+        Game game = new Game(new BoardFactoryStub(new Board(3)), gamePrompt, new PlayerFactoryStub(
                 new PlayerSpy(X, createCommandPromptToReadInput("1\n5\n6\n7\n8\n")),
                 new PlayerSpy(O, createCommandPromptToReadInput("2\n3\n4\n9\n")))
         );
@@ -34,14 +55,14 @@ public class GameTest {
     public void playersTakeTurnsUntilTheBoardIsFull() {
         PlayerSpy player1Spy = new PlayerSpy(X, createCommandPromptToReadInput("1\n5\n6\n7\n8\n"));
         PlayerSpy player2Spy = new PlayerSpy(O, createCommandPromptToReadInput("2\n3\n4\n9\n"));
-        PlayerFactorySpy playerFactorySpy = new PlayerFactorySpy(
+        PlayerFactoryStub playerFactoryStub = new PlayerFactoryStub(
                 player1Spy,
                 player2Spy
         );
 
-        Game game = new Game(new Board(),
-                createCommandPromptToReadInput("1\nN\n"),
-                playerFactorySpy);
+        Game game = new Game(new BoardFactoryStub(new Board(3)),
+                createCommandPromptToReadInput(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY),
+                playerFactoryStub);
 
         game.play();
 
@@ -51,14 +72,14 @@ public class GameTest {
 
     @Test
     public void printsCongratulatoryMessageWhenThereIsAWinningFormation() {
-        PromptSpy gamePrompt = new PromptSpy(new StringReader("1\nN\n"));
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
 
-        PlayerFactorySpy playerFactorySpy = new PlayerFactorySpy(
-                createHumanPlayer(createCommandPromptToReadInput("1\n2\n3\n"), X),
-                createHumanPlayer(createCommandPromptToReadInput("5\n8\n"), O)
+        PlayerFactoryStub playerFactorySpy = new PlayerFactoryStub(
+                createHumanPlayer(X, createCommandPromptToReadInput("1\n2\n3\n")),
+                createHumanPlayer(O, createCommandPromptToReadInput("5\n8\n"))
         );
 
-        Game game = new Game(new Board(),
+        Game game = new Game(new BoardFactoryStub(new Board(3)),
                 gamePrompt,
                 playerFactorySpy);
 
@@ -72,16 +93,16 @@ public class GameTest {
     @Test
     public void printsDrawMessageWhenThereAreNoMoreSpacesOnTheBoardAndNoWinner() {
         Board board = new Board(X, O, O, O, X, X, VACANT, VACANT, O);
-        PromptSpy gamePrompt = new PromptSpy(new StringReader("1\nN\n"));
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
 
-        PlayerFactorySpy playerFactorySpy = new PlayerFactorySpy(
-                createHumanPlayer(createCommandPromptToReadInput("8\n"), X),
-                createHumanPlayer(createCommandPromptToReadInput("7\n"), O)
+        PlayerFactoryStub playerFactoryStub = new PlayerFactoryStub(
+                createHumanPlayer(X, createCommandPromptToReadInput("8\n")),
+                createHumanPlayer(O, createCommandPromptToReadInput("7\n"))
         );
 
-        Game game = new Game(board,
+        Game game = new Game(new BoardFactoryStub(board),
                 gamePrompt,
-                playerFactorySpy);
+                playerFactoryStub);
 
         game.play();
 
@@ -93,14 +114,14 @@ public class GameTest {
     @Test
     public void printsTheFinalStateOfTheBoard() {
         Board board = new Board(X, VACANT, X, O, X, O, O, O, X);
-        PromptSpy gamePrompt = new PromptSpy(new StringReader("1\nN\n"));
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
 
-        PlayerFactorySpy playerFactorySpy = new PlayerFactorySpy(
-                createHumanPlayer(createCommandPromptToReadInput("2\n"), X),
-                createHumanPlayer(createCommandPromptToReadInput("\n"), O)
+        PlayerFactoryStub playerFactoryStub = new PlayerFactoryStub(
+                createHumanPlayer(X, createCommandPromptToReadInput("2\n")),
+                createHumanPlayer(O, createCommandPromptToReadInput("\n"))
         );
 
-        Game game = new Game(board, gamePrompt, playerFactorySpy);
+        Game game = new Game(new BoardFactoryStub(board), gamePrompt, playerFactoryStub);
 
         game.play();
 
@@ -110,14 +131,14 @@ public class GameTest {
     @Test
     public void promptsToPlayAgain() {
         Board board = new Board(X, VACANT, X, O, X, O, O, O, X);
-        PromptSpy gamePrompt = new PromptSpy(new StringReader("1\nY\n1\nN\n"));
+        PromptSpy gamePrompt = new PromptSpy(new StringReader(DIMENSION + HUMAN_VS_HUMAN + REPLAY + DIMENSION + HUMAN_VS_HUMAN + DO_NOT_REPLAY));
 
-        PlayerFactorySpy playerFactorySpy = new PlayerFactorySpy(
-                createHumanPlayer(createCommandPromptToReadInput("2\n2\n3\n5\n"), X),
-                createHumanPlayer(createCommandPromptToReadInput("1\n4\n7\n"), O)
+        PlayerFactoryStub playerFactoryStub = new PlayerFactoryStub(
+                createHumanPlayer(X, createCommandPromptToReadInput("2\n2\n3\n5\n")),
+                createHumanPlayer(O, createCommandPromptToReadInput("1\n4\n7\n"))
         );
 
-        Game game = new Game(board, gamePrompt, playerFactorySpy);
+        Game game = new Game(new BoardFactoryStub(board, new Board(3)), gamePrompt, playerFactoryStub);
 
         game.play();
 
@@ -125,13 +146,14 @@ public class GameTest {
         assertThat(gamePrompt.getNumberOfTimesOHasWon(), is(1));
         assertThat(gamePrompt.getNumberOfTimesPlayerIsPromptedToPlayAgain(), is(2));
         assertThat(gamePrompt.getNumberOfTimesPromptedForPlayerOption(), is(2));
+        assertThat(gamePrompt.getNumberOfTimesBoardDimensionPrompted(), is(2));
     }
 
     private Prompt createCommandPromptToReadInput(String usersInputs) {
         return new CommandPrompt(new StringReader(usersInputs), new StringWriter());
     }
 
-    private HumanPlayer createHumanPlayer(Prompt prompt, PlayerSymbol symbol) {
+    private HumanPlayer createHumanPlayer(PlayerSymbol symbol, Prompt prompt) {
         return new HumanPlayer(symbol, prompt);
     }
 }

--- a/src/test/java/ttt/GameTypeTest.java
+++ b/src/test/java/ttt/GameTypeTest.java
@@ -30,4 +30,29 @@ public class GameTypeTest {
         GameType gameType = GameType.of(100);
         assertThat(gameType, is(GameType.HUMAN_VS_HUMAN));
     }
+
+    @Test
+    public void getPossibleDimensionForHumanVsHuman() {
+        GameType gameType = GameType.of(1);
+        assertThat(gameType.dimensionUpperBoundary(), is(10));
+    }
+
+    @Test
+    public void getPossibleDimensionForHumanVsUnbeatable() {
+        GameType gameType = GameType.of(2);
+        assertThat(gameType.dimensionUpperBoundary(), is(4));
+    }
+
+    @Test
+    public void getPossibleDimensionForUnbeatableVsHuman() {
+        GameType gameType = GameType.of(3);
+        assertThat(gameType.dimensionUpperBoundary(), is(4));
+    }
+
+    @Test
+    public void getsLowerBoundaryForDimension() {
+        GameType gameType = GameType.of(3);
+        assertThat(gameType.dimensionLowerBoundary(), is(1));
+    }
+
 }

--- a/src/test/java/ttt/PlayerFactoryStub.java
+++ b/src/test/java/ttt/PlayerFactoryStub.java
@@ -12,7 +12,7 @@ public class PlayerFactoryStub extends PlayerFactory {
     }
 
     @Override
-    public Player[] createPlayers(GameType playerOption, Prompt prompt) {
+    public Player[] createPlayers(GameType playerOption, Prompt prompt, int dimension) {
         return players;
     }
 }

--- a/src/test/java/ttt/PlayerFactoryStub.java
+++ b/src/test/java/ttt/PlayerFactoryStub.java
@@ -4,10 +4,10 @@ import ttt.player.Player;
 import ttt.player.PlayerFactory;
 import ttt.ui.Prompt;
 
-public class PlayerFactorySpy extends PlayerFactory {
+public class PlayerFactoryStub extends PlayerFactory {
     private Player[] players;
 
-    public PlayerFactorySpy(Player... players) {
+    public PlayerFactoryStub(Player... players) {
         this.players = players;
     }
 

--- a/src/test/java/ttt/PromptSpy.java
+++ b/src/test/java/ttt/PromptSpy.java
@@ -8,6 +8,7 @@ import ttt.ui.Prompt;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.List;
 
 import static ttt.player.PlayerSymbol.O;
 import static ttt.player.PlayerSymbol.X;
@@ -92,7 +93,7 @@ public class PromptSpy implements Prompt {
 
     public String getLastBoardThatWasPrinted() {
         StringBuilder gridFormation = new StringBuilder();
-        Line[] rows = lastBoardPrinted.getRows();
+        List<Line> rows = lastBoardPrinted.getRows();
 
         for (Line row : rows) {
             for (PlayerSymbol symbol : row.getSymbols()) {

--- a/src/test/java/ttt/PromptSpy.java
+++ b/src/test/java/ttt/PromptSpy.java
@@ -23,7 +23,7 @@ public class PromptSpy implements Prompt {
     private int numberOfTimesBoardDimensionPrompted = 0;
 
     @Override
-    public int getBoardDimension() {
+    public int getBoardDimension(GameType gameType) {
         numberOfTimesBoardDimensionPrompted++;
         return Integer.valueOf(readInput());
     }

--- a/src/test/java/ttt/PromptSpy.java
+++ b/src/test/java/ttt/PromptSpy.java
@@ -20,6 +20,13 @@ public class PromptSpy implements Prompt {
     private int numberOfTimesOHasWon = 0;
     private int numberOfTimesPlayerIsReprompted = 0;
     private int numberOfTimesPlayerOptionsHaveBeenPrinted;
+    private int numberOfTimesBoardDimensionPrompted = 0;
+
+    @Override
+    public int getBoardDimension() {
+        numberOfTimesBoardDimensionPrompted++;
+        return Integer.valueOf(readInput());
+    }
 
     public PromptSpy(Reader reader) {
         this.reader = new BufferedReader(reader);
@@ -102,5 +109,9 @@ public class PromptSpy implements Prompt {
 
     public int getNumberOfTimesPromptedForPlayerOption() {
         return numberOfTimesPlayerOptionsHaveBeenPrinted;
+    }
+
+    public int getNumberOfTimesBoardDimensionPrompted() {
+        return numberOfTimesBoardDimensionPrompted;
     }
 }

--- a/src/test/java/ttt/RandomPlayer.java
+++ b/src/test/java/ttt/RandomPlayer.java
@@ -14,7 +14,7 @@ public class RandomPlayer extends Player {
 
     @Override
     public int chooseNextMoveFrom(Board board) {
-        int dimension = board.getRows().length;
+        int dimension = board.getRows().size();
         int randomMove = generateRandomNumber(dimension);
         while (!(board.isWithinGridBoundary(randomMove) && board.isVacantAt(randomMove))) {
             System.out.println("Reprompting as " + randomMove + " is invalid");

--- a/src/test/java/ttt/RandomPlayer.java
+++ b/src/test/java/ttt/RandomPlayer.java
@@ -8,25 +8,25 @@ import ttt.ui.Prompt;
 import java.util.Random;
 
 public class RandomPlayer extends Player {
-    private static final int UPPER_BOUND = 9;
-    private static final int LOWER_BOUND = 0;
-
     public RandomPlayer(PlayerSymbol playerSymbol, Prompt prompt) {
         super(playerSymbol, prompt);
     }
 
     @Override
     public int chooseNextMoveFrom(Board board) {
-        int randomMove = generateRandomNumberFrom0To8();
+        int dimension = board.getRows().length;
+        int randomMove = generateRandomNumber(dimension);
         while (!(board.isWithinGridBoundary(randomMove) && board.isVacantAt(randomMove))) {
             System.out.println("Reprompting as " + randomMove + " is invalid");
-            randomMove = generateRandomNumberFrom0To8();
+            randomMove = generateRandomNumber(dimension);
         }
         System.out.println("Random number generated " + randomMove);
         return randomMove;
     }
 
-    private int generateRandomNumberFrom0To8() {
-        return new Random().nextInt(UPPER_BOUND - LOWER_BOUND) + LOWER_BOUND;
+    private int generateRandomNumber(int dimension) {
+        int lowerBoundary = 0;
+        int upperBoundary = dimension * dimension;
+        return new Random().nextInt(upperBoundary - lowerBoundary) + lowerBoundary;
     }
 }

--- a/src/test/java/ttt/UnbeatablePlayerIsUnbeatableTest.java
+++ b/src/test/java/ttt/UnbeatablePlayerIsUnbeatableTest.java
@@ -15,12 +15,16 @@ import static ttt.player.PlayerSymbol.X;
 
 public class UnbeatablePlayerIsUnbeatableTest {
     private static final int NUMBER_OF_GAMES = 100;
+    private static final String DIMENSION = "3\n";
+    private static final String PLAYER_CHOICE = "1\n";
+    private static final String REPROMPT = "Y\n";
+    private static final String DO_NOT_REPLAY = "N\n";
 
     @Test
     public void unbeatablePlayerNeverLoosesWhenTheyOpenTheGame() {
         PromptSpy promptSpy = new PromptSpy(new StringReader(replayAndGameTypeInputForGame()));
-        PlayerFactory playerFactory = new PlayerFactorySpy(new UnbeatablePlayer(X), new RandomPlayer(O, promptSpy));
-        Game gameWithManyRounds = new Game(new Board(), promptSpy, playerFactory);
+        PlayerFactory playerFactory = new PlayerFactoryStub(new UnbeatablePlayer(X), new RandomPlayer(O, promptSpy));
+        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGame()), promptSpy, playerFactory);
 
         gameWithManyRounds.play();
 
@@ -31,8 +35,8 @@ public class UnbeatablePlayerIsUnbeatableTest {
     @Test
     public void unbeatablePlayerNeverLoosesWhenTheyDoNotOpenTheGame() {
         PromptSpy promptSpy = new PromptSpy(new StringReader(replayAndGameTypeInputForGame()));
-        PlayerFactory playerFactory = new PlayerFactorySpy(new RandomPlayer(O, promptSpy), new UnbeatablePlayer(X));
-        Game gameWithManyRounds = new Game(new Board(), promptSpy, playerFactory);
+        PlayerFactory playerFactory = new PlayerFactoryStub(new RandomPlayer(O, promptSpy), new UnbeatablePlayer(X));
+        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGame()), promptSpy, playerFactory);
 
         gameWithManyRounds.play();
 
@@ -43,8 +47,8 @@ public class UnbeatablePlayerIsUnbeatableTest {
     @Test
     public void unbeatableVsUnbeatableHasNoGamesWon() {
         PromptSpy promptSpy = new PromptSpy(new StringReader(replayAndGameTypeInputForGame()));
-        PlayerFactory playerFactory = new PlayerFactorySpy(new UnbeatablePlayer(O), new UnbeatablePlayer(X));
-        Game gameWithManyRounds = new Game(new Board(), promptSpy, playerFactory);
+        PlayerFactory playerFactory = new PlayerFactoryStub(new UnbeatablePlayer(O), new UnbeatablePlayer(X));
+        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGame()), promptSpy, playerFactory);
 
         gameWithManyRounds.play();
 
@@ -54,10 +58,19 @@ public class UnbeatablePlayerIsUnbeatableTest {
 
     private String replayAndGameTypeInputForGame() {
         String userInput = "";
+
         for (int gameNumber = 0; gameNumber < NUMBER_OF_GAMES - 1; gameNumber++) {
-            userInput += "1\nY\n";
+            userInput += DIMENSION + PLAYER_CHOICE + REPROMPT;
         }
-        userInput += "1\nN\n";
+        userInput += DIMENSION + PLAYER_CHOICE + DO_NOT_REPLAY;
         return userInput;
+    }
+
+    private Board[] emptyGridPerGame() {
+        Board[] emptyGridPerGame = new Board[NUMBER_OF_GAMES];
+        for (int i = 0; i < NUMBER_OF_GAMES; i++) {
+            emptyGridPerGame[i] = new Board(3);
+        }
+        return emptyGridPerGame;
     }
 }

--- a/src/test/java/ttt/UnbeatablePlayerIsUnbeatableTest.java
+++ b/src/test/java/ttt/UnbeatablePlayerIsUnbeatableTest.java
@@ -2,6 +2,7 @@ package ttt;
 
 import org.junit.Test;
 import ttt.board.Board;
+import ttt.player.DelayedUnbeatablePlayer;
 import ttt.player.PlayerFactory;
 import ttt.player.UnbeatablePlayer;
 
@@ -15,16 +16,15 @@ import static ttt.player.PlayerSymbol.X;
 
 public class UnbeatablePlayerIsUnbeatableTest {
     private static final int NUMBER_OF_GAMES = 100;
-    private static final String DIMENSION = "3\n";
     private static final String PLAYER_CHOICE = "1\n";
     private static final String REPROMPT = "Y\n";
     private static final String DO_NOT_REPLAY = "N\n";
 
     @Test
-    public void unbeatablePlayerNeverLoosesWhenTheyOpenTheGame() {
-        PromptSpy promptSpy = new PromptSpy(new StringReader(replayAndGameTypeInputForGame()));
+    public void unbeatablePlayerNeverLoosesWhenTheyOpenTheGameIn3x3() {
+        PromptSpy promptSpy = new PromptSpy(new StringReader(setupForGameWithBoardDimensionOf(3)));
         PlayerFactory playerFactory = new PlayerFactoryStub(new UnbeatablePlayer(X), new RandomPlayer(O, promptSpy));
-        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGame()), promptSpy, playerFactory);
+        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGameWithDimension(3)), promptSpy, playerFactory);
 
         gameWithManyRounds.play();
 
@@ -33,10 +33,10 @@ public class UnbeatablePlayerIsUnbeatableTest {
     }
 
     @Test
-    public void unbeatablePlayerNeverLoosesWhenTheyDoNotOpenTheGame() {
-        PromptSpy promptSpy = new PromptSpy(new StringReader(replayAndGameTypeInputForGame()));
+    public void unbeatablePlayerNeverLoosesWhenTheyDoNotOpenTheGameIn3x3() {
+        PromptSpy promptSpy = new PromptSpy(new StringReader(setupForGameWithBoardDimensionOf(3)));
         PlayerFactory playerFactory = new PlayerFactoryStub(new RandomPlayer(O, promptSpy), new UnbeatablePlayer(X));
-        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGame()), promptSpy, playerFactory);
+        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGameWithDimension(3)), promptSpy, playerFactory);
 
         gameWithManyRounds.play();
 
@@ -45,10 +45,10 @@ public class UnbeatablePlayerIsUnbeatableTest {
     }
 
     @Test
-    public void unbeatableVsUnbeatableHasNoGamesWon() {
-        PromptSpy promptSpy = new PromptSpy(new StringReader(replayAndGameTypeInputForGame()));
+    public void unbeatableVsUnbeatableHasNoGamesWonIn3x3() {
+        PromptSpy promptSpy = new PromptSpy(new StringReader(setupForGameWithBoardDimensionOf(3)));
         PlayerFactory playerFactory = new PlayerFactoryStub(new UnbeatablePlayer(O), new UnbeatablePlayer(X));
-        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGame()), promptSpy, playerFactory);
+        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGameWithDimension(3)), promptSpy, playerFactory);
 
         gameWithManyRounds.play();
 
@@ -56,20 +56,56 @@ public class UnbeatablePlayerIsUnbeatableTest {
         assertThat(promptSpy.getNumberOfTimesXHasWon(), is(0));
     }
 
-    private String replayAndGameTypeInputForGame() {
+    @Test
+    public void delayedUnbeatablePlayerNeverLoosesWhenTheyOpenTheGameIn4x4() {
+        PromptSpy promptSpy = new PromptSpy(new StringReader(setupForGameWithBoardDimensionOf(4)));
+        PlayerFactory playerFactory = new PlayerFactoryStub(new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X)), new RandomPlayer(O, promptSpy));
+        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGameWithDimension(4)), promptSpy, playerFactory);
+
+        gameWithManyRounds.play();
+
+        assertThat(promptSpy.getNumberOfTimesOHasWon(), is(0));
+        assertThat(promptSpy.getNumberOfTimesXHasWon(), greaterThan(1));
+    }
+
+    @Test
+    public void delayedUnbeatablePlayerNeverLoosesWhenTheyDoNotOpenTheGameIn4x4() {
+        PromptSpy promptSpy = new PromptSpy(new StringReader(setupForGameWithBoardDimensionOf(4)));
+        PlayerFactory playerFactory = new PlayerFactoryStub(new RandomPlayer(O, promptSpy), new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X)));
+        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGameWithDimension(4)), promptSpy, playerFactory);
+
+        gameWithManyRounds.play();
+
+        assertThat(promptSpy.getNumberOfTimesOHasWon(), is(0));
+        assertThat(promptSpy.getNumberOfTimesXHasWon(), greaterThan(1));
+    }
+
+    @Test
+    public void delayedUnbeatableVsDelayedUnbeatableHasNoGamesWonIn4x4() {
+        PromptSpy promptSpy = new PromptSpy(new StringReader(setupForGameWithBoardDimensionOf(4)));
+        PlayerFactory playerFactory = new PlayerFactoryStub(new DelayedUnbeatablePlayer(O, new UnbeatablePlayer(O)), new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X)));
+        Game gameWithManyRounds = new Game(new BoardFactoryStub(emptyGridPerGameWithDimension(4)), promptSpy, playerFactory);
+
+        gameWithManyRounds.play();
+
+        assertThat(promptSpy.getNumberOfTimesOHasWon(), is(0));
+        assertThat(promptSpy.getNumberOfTimesXHasWon(), is(0));
+    }
+
+    private String setupForGameWithBoardDimensionOf(int dimension) {
         String userInput = "";
 
         for (int gameNumber = 0; gameNumber < NUMBER_OF_GAMES - 1; gameNumber++) {
-            userInput += DIMENSION + PLAYER_CHOICE + REPROMPT;
+            userInput += dimension + "\n" + PLAYER_CHOICE + REPROMPT;
         }
-        userInput += DIMENSION + PLAYER_CHOICE + DO_NOT_REPLAY;
+        userInput += dimension + "\n" + PLAYER_CHOICE + DO_NOT_REPLAY;
         return userInput;
     }
 
-    private Board[] emptyGridPerGame() {
+    private Board[] emptyGridPerGameWithDimension(int dimension) {
         Board[] emptyGridPerGame = new Board[NUMBER_OF_GAMES];
         for (int i = 0; i < NUMBER_OF_GAMES; i++) {
-            emptyGridPerGame[i] = new Board(3);
+            emptyGridPerGame[i] = new Board(dimension);
         }
         return emptyGridPerGame;
     }

--- a/src/test/java/ttt/board/BoardFactoryTest.java
+++ b/src/test/java/ttt/board/BoardFactoryTest.java
@@ -12,7 +12,7 @@ public class BoardFactoryTest {
         BoardFactory boardFactory = new BoardFactory();
         Board board = boardFactory.createBoardWithSize(3);
 
-        assertThat(board.getRows().length, is(3));
+        assertThat(board.getRows().size(), is(3));
     }
 
     @Test
@@ -20,6 +20,6 @@ public class BoardFactoryTest {
         BoardFactory boardFactory = new BoardFactory();
         Board board = boardFactory.createBoardWithSize(4);
 
-        assertThat(board.getRows().length, is(4));
+        assertThat(board.getRows().size(), is(4));
     }
 }

--- a/src/test/java/ttt/board/BoardFactoryTest.java
+++ b/src/test/java/ttt/board/BoardFactoryTest.java
@@ -1,0 +1,25 @@
+package ttt.board;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class BoardFactoryTest {
+
+    @Test
+    public void creates3x3Board() {
+        BoardFactory boardFactory = new BoardFactory();
+        Board board = boardFactory.createBoardWithSize(3);
+
+        assertThat(board.getRows().length, is(3));
+    }
+
+    @Test
+    public void creates4x4Board() {
+        BoardFactory boardFactory = new BoardFactory();
+        Board board = boardFactory.createBoardWithSize(4);
+
+        assertThat(board.getRows().length, is(4));
+    }
+}

--- a/src/test/java/ttt/board/BoardTest.java
+++ b/src/test/java/ttt/board/BoardTest.java
@@ -13,6 +13,18 @@ import static ttt.player.PlayerSymbol.*;
 public class BoardTest {
 
     @Test
+    public void creates3x3Board() {
+        Board board = new Board(3);
+        assertThat(board.getVacantPositions(), is(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8)));
+    }
+
+    @Test
+    public void creates4x4Board() {
+        Board board = new Board(4);
+        assertThat(board.getVacantPositions(), is(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)));
+    }
+
+    @Test
     public void getsSymbolFromSpecifiedPosition() {
         Board board = new Board(X, X, O, X, VACANT, O, O, X, X);
         assertThat(board.getSymbolAt(4), is(VACANT));
@@ -20,13 +32,13 @@ public class BoardTest {
 
     @Test
     public void identifiesThatThereIsAFreeSpaceOnTheBoard() {
-        Board board = new Board();
+        Board board = new Board(3);
         assertTrue(board.hasFreeSpace());
     }
 
     @Test
     public void identifiesThatGivenSlotOnBoardIsVacant() {
-        Board board = new Board();
+        Board board = new Board(3);
         assertTrue(board.isVacantAt(1));
     }
 
@@ -44,7 +56,7 @@ public class BoardTest {
 
     @Test
     public void noWinningRowWhenBoardIsAllVacant() {
-        Board board = new Board();
+        Board board = new Board(3);
         assertThat(board.hasWinningCombination(), is(false));
     }
 
@@ -164,13 +176,13 @@ public class BoardTest {
 
     @Test
     public void winningSymbolIdentifiedAsVacantIfNoWinsOnBoard() {
-        Board board = new Board();
+        Board board = new Board(3);
         assertThat(board.getWinningSymbol(), is(VACANT));
     }
 
     @Test
     public void updateBoardWithSpecificSymbolAtGivenPosition() {
-        Board board = new Board();
+        Board board = new Board(3);
         board.updateAt(2, X);
 
         assertThat(board.getSymbolAt(2), is(X));
@@ -178,37 +190,37 @@ public class BoardTest {
 
     @Test
     public void indicatesPositionLargerThanGridIsOutsideOfGrid() {
-        Board board = new Board();
+        Board board = new Board(3);
         assertThat(board.isWithinGridBoundary(9), is(false));
     }
 
     @Test
     public void indicatesPositionAtZeroIsInsideOfGrid() {
-        Board board = new Board();
+        Board board = new Board(3);
         assertThat(board.isWithinGridBoundary(0), is(true));
     }
 
     @Test
     public void indicatesPositionEightIsValid() {
-        Board board = new Board();
+        Board board = new Board(3);
         assertThat(board.isWithinGridBoundary(8), is(true));
     }
 
     @Test
     public void indicatesPositionLessThanZeroIsOutsideOfGrid() {
-        Board board = new Board();
+        Board board = new Board(3);
         assertThat(board.isWithinGridBoundary(-3), is(false));
     }
 
     @Test
     public void indicatesPositionIsWithinGridBoundary() {
-        Board board = new Board();
+        Board board = new Board(3);
         assertThat(board.isWithinGridBoundary(2), is(true));
     }
 
     @Test
     public void allPositionsReturnedForEmptyBoard() {
-        Board board = new Board();
+        Board board = new Board(3);
 
         List<Integer> freePositions = board.getVacantPositions();
 
@@ -242,8 +254,8 @@ public class BoardTest {
 
         Line[] rows = board.getRows();
 
-        PlayerSymbol[] expectedTopRow = new PlayerSymbol[]{ X, O, X};
-        PlayerSymbol[] expectedMiddleRow = new PlayerSymbol[]{ O, O, X};
+        PlayerSymbol[] expectedTopRow = new PlayerSymbol[]{X, O, X};
+        PlayerSymbol[] expectedMiddleRow = new PlayerSymbol[]{O, O, X};
         PlayerSymbol[] expectedBottomRow = new PlayerSymbol[]{VACANT, VACANT, O};
 
         assertThat(rows.length, is(3));

--- a/src/test/java/ttt/board/BoardTest.java
+++ b/src/test/java/ttt/board/BoardTest.java
@@ -252,15 +252,15 @@ public class BoardTest {
     public void returnsHorizontalRows() {
         Board board = new Board(X, O, X, O, O, X, VACANT, VACANT, O);
 
-        Line[] rows = board.getRows();
+        List<Line> rows = board.getRows();
 
         PlayerSymbol[] expectedTopRow = new PlayerSymbol[]{X, O, X};
         PlayerSymbol[] expectedMiddleRow = new PlayerSymbol[]{O, O, X};
         PlayerSymbol[] expectedBottomRow = new PlayerSymbol[]{VACANT, VACANT, O};
 
-        assertThat(rows.length, is(3));
-        assertThat(rows[0].getSymbols(), is(expectedTopRow));
-        assertThat(rows[1].getSymbols(), is(expectedMiddleRow));
-        assertThat(rows[2].getSymbols(), is(expectedBottomRow));
+        assertThat(rows.size(), is(3));
+        assertThat(rows.get(0).getSymbols(), is(expectedTopRow));
+        assertThat(rows.get(1).getSymbols(), is(expectedMiddleRow));
+        assertThat(rows.get(2).getSymbols(), is(expectedBottomRow));
     }
 }

--- a/src/test/java/ttt/board/LineGeneratorTest.java
+++ b/src/test/java/ttt/board/LineGeneratorTest.java
@@ -5,6 +5,8 @@ import ttt.player.PlayerSymbol;
 
 import java.util.Arrays;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static ttt.player.PlayerSymbol.*;
@@ -12,29 +14,138 @@ import static ttt.player.PlayerSymbol.*;
 public class LineGeneratorTest {
 
     @Test
-    public void identifiesWinningRowOfX() {
-        LineGenerator lineGenerator = new LineGenerator(X, X, X, VACANT, VACANT, VACANT, VACANT, VACANT, VACANT);
+    public void identifiesWinningRowOfXIn3x3() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, X, X,
+                VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT
+        );
 
-        assertTrue(lineGenerator.topRow().isWinning());
+        Line[] horizontalRows = lineGenerator.getRows();
+        assertTrue(horizontalRows[0].isWinning());
     }
 
     @Test
-    public void identifiesWinningRowOfO() {
-        LineGenerator lineGenerator = new LineGenerator(X, X, VACANT, O, O, O, VACANT, VACANT, VACANT);
+    public void identifiesWinningRowOfOIn3x3() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, X, VACANT,
+                O, O, O,
+                VACANT, VACANT, VACANT
+        );
 
-        assertTrue(lineGenerator.middleRow().isWinning());
+        Line[] horizontalRows = lineGenerator.getRows();
+        assertTrue(horizontalRows[1].isWinning());
     }
 
     @Test
-    public void identifiesNoWinningRow() {
-        LineGenerator lineGenerator = new LineGenerator(X, X, VACANT, O, O, VACANT, VACANT, VACANT, VACANT);
+    public void identifiesNoWinningRowIn3x3() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, X, VACANT,
+                O, O, VACANT,
+                VACANT, VACANT, VACANT
+        );
 
-        assertFalse(lineGenerator.middleRow().isWinning());
+        Line[] horizontalRows = lineGenerator.getRows();
+        assertFalse(horizontalRows[2].isWinning());
     }
 
     @Test
-    public void symbolsOfLine() {
-        LineGenerator lineGenerator = new LineGenerator(X, X, X, VACANT, VACANT, VACANT, VACANT, VACANT, VACANT);
-        assertTrue(Arrays.equals(lineGenerator.topRow().getSymbols(), new PlayerSymbol[]{X, X, X}));
+    public void symbolsOfLineIn3x3() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, X, X,
+                VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT
+        );
+        Line[] horizontalRows = lineGenerator.getRows();
+        assertTrue(Arrays.equals(horizontalRows[0].getSymbols(), new PlayerSymbol[]{X, X, X}));
     }
+
+    @Test
+    public void getsFourHorizontalRowsFor4x4() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, X, X, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT
+        );
+        assertThat(lineGenerator.getRows().length, is(4));
+    }
+
+    @Test
+    public void identifiesNoWinIn4x4() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, X, X, VACANT,
+                O, O, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT
+        );
+
+        Line[] horizontalRows = lineGenerator.getRows();
+        assertFalse(horizontalRows[0].isWinning());
+    }
+
+    @Test
+    public void identifiesWinningRowOfXIn4x4() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, X, X, X,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT
+        );
+
+        Line[] horizontalRows = lineGenerator.getRows();
+        assertTrue(horizontalRows[0].isWinning());
+    }
+
+    @Test
+    public void identifiesWinningColumnIn4x4() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, VACANT, VACANT, VACANT,
+                X, VACANT, VACANT, VACANT,
+                X, VACANT, VACANT, VACANT,
+                X, VACANT, VACANT, VACANT
+        );
+
+        Line[] rows = lineGenerator.linesForAllDirections();
+        assertTrue(rows[4].isWinning());
+    }
+
+    @Test
+    public void identifiesWinningBackslashDiagonalIn4x4Grid() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, VACANT, VACANT, VACANT,
+                VACANT, X, VACANT, VACANT,
+                VACANT, VACANT, X, VACANT,
+                VACANT, VACANT, VACANT, X
+        );
+
+        Line[] rows = lineGenerator.linesForAllDirections();
+        assertTrue(rows[8].isWinning());
+    }
+
+    @Test
+    public void identifiesWinningForwardslashDiagonalIn4x4Grid() {
+        LineGenerator lineGenerator = new LineGenerator(
+                VACANT, VACANT, VACANT, X,
+                VACANT, VACANT, X, VACANT,
+                VACANT, X, VACANT, VACANT,
+                X, VACANT, VACANT, VACANT
+        );
+
+        Line[] rows = lineGenerator.linesForAllDirections();
+        assertTrue(rows[9].isWinning());
+    }
+
+
+    @Test
+    public void allLinesIn4x4() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, X, X, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT
+        );
+        assertThat(lineGenerator.linesForAllDirections().length, is(10));
+    }
+
 }

--- a/src/test/java/ttt/board/LineGeneratorTest.java
+++ b/src/test/java/ttt/board/LineGeneratorTest.java
@@ -1,15 +1,13 @@
 package ttt.board;
 
-import org.junit.Assert;
 import org.junit.Test;
 import ttt.player.PlayerSymbol;
 
 import java.util.Arrays;
+import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static ttt.player.PlayerSymbol.*;
 
 public class LineGeneratorTest {
@@ -22,8 +20,8 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT
         );
 
-        Line[] horizontalRows = lineGenerator.getRows();
-        assertTrue(horizontalRows[0].isWinning());
+        List<Line> horizontalRows = lineGenerator.getRows();
+        assertTrue(horizontalRows.get(0).isWinning());
     }
 
     @Test
@@ -34,8 +32,8 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT
         );
 
-        Line[] horizontalRows = lineGenerator.getRows();
-        assertTrue(horizontalRows[1].isWinning());
+        List<Line> horizontalRows = lineGenerator.getRows();
+        assertTrue(horizontalRows.get(1).isWinning());
     }
 
     @Test
@@ -46,8 +44,8 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT
         );
 
-        Line[] horizontalRows = lineGenerator.getRows();
-        assertFalse(horizontalRows[2].isWinning());
+        List<Line> horizontalRows = lineGenerator.getRows();
+        assertFalse(horizontalRows.get(2).isWinning());
     }
 
     @Test
@@ -57,8 +55,8 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT,
                 VACANT, VACANT, VACANT
         );
-        Line[] horizontalRows = lineGenerator.getRows();
-        assertTrue(Arrays.equals(horizontalRows[0].getSymbols(), new PlayerSymbol[]{X, X, X}));
+        List<Line> horizontalRows = lineGenerator.getRows();
+        assertTrue(Arrays.equals(horizontalRows.get(0).getSymbols(), new PlayerSymbol[]{X, X, X}));
     }
 
     @Test
@@ -68,17 +66,17 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT,
                 O, VACANT, VACANT
         );
-        Line[] lines = lineGenerator.linesForAllDirections();
-        assertThat(lines.length, is(8));
+        List<Line> lines = lineGenerator.linesForAllDirections();
+        assertThat(lines.size(), is(8));
 
-        Assert.assertThat(lines[0].getSymbols(), is(new PlayerSymbol[]{X, X, X}));
-        Assert.assertThat(lines[1].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT}));
-        Assert.assertThat(lines[2].getSymbols(), is(new PlayerSymbol[]{O, VACANT, VACANT}));
-        Assert.assertThat(lines[3].getSymbols(), is(new PlayerSymbol[]{X, VACANT, O}));
-        Assert.assertThat(lines[4].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT}));
-        Assert.assertThat(lines[5].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT}));
-        Assert.assertThat(lines[6].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT}));
-        Assert.assertThat(lines[7].getSymbols(), is(new PlayerSymbol[]{X, VACANT, O}));
+        assertThat(lines.get(0).getSymbols(), is(new PlayerSymbol[]{X, X, X}));
+        assertThat(lines.get(1).getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT}));
+        assertThat(lines.get(2).getSymbols(), is(new PlayerSymbol[]{O, VACANT, VACANT}));
+        assertThat(lines.get(3).getSymbols(), is(new PlayerSymbol[]{X, VACANT, O}));
+        assertThat(lines.get(4).getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT}));
+        assertThat(lines.get(5).getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT}));
+        assertThat(lines.get(6).getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT}));
+        assertThat(lines.get(7).getSymbols(), is(new PlayerSymbol[]{X, VACANT, O}));
     }
 
     @Test
@@ -90,8 +88,8 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT, VACANT
         );
 
-        Line[] horizontalRows = lineGenerator.getRows();
-        assertFalse(horizontalRows[0].isWinning());
+        List<Line> horizontalRows = lineGenerator.getRows();
+        assertFalse(horizontalRows.get(0).isWinning());
     }
 
     @Test
@@ -103,8 +101,8 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT, VACANT
         );
 
-        Line[] horizontalRows = lineGenerator.getRows();
-        assertTrue(horizontalRows[0].isWinning());
+        List<Line> horizontalRows = lineGenerator.getRows();
+        assertTrue(horizontalRows.get(0).isWinning());
     }
 
     @Test
@@ -116,8 +114,8 @@ public class LineGeneratorTest {
                 X, VACANT, VACANT, VACANT
         );
 
-        Line[] rows = lineGenerator.linesForAllDirections();
-        assertTrue(rows[4].isWinning());
+        List<Line> rows = lineGenerator.linesForAllDirections();
+        assertTrue(rows.get(4).isWinning());
     }
 
     @Test
@@ -129,8 +127,8 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT, X
         );
 
-        Line[] rows = lineGenerator.linesForAllDirections();
-        assertTrue(rows[8].isWinning());
+        List<Line> rows = lineGenerator.linesForAllDirections();
+        assertTrue(rows.get(8).isWinning());
     }
 
     @Test
@@ -142,8 +140,8 @@ public class LineGeneratorTest {
                 X, VACANT, VACANT, VACANT
         );
 
-        Line[] rows = lineGenerator.linesForAllDirections();
-        assertTrue(rows[9].isWinning());
+        List<Line> rows = lineGenerator.linesForAllDirections();
+        assertTrue(rows.get(9).isWinning());
     }
 
     @Test
@@ -154,8 +152,8 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT, O,
                 VACANT, VACANT, O, VACANT
         );
-        Line[] horizontalRows = lineGenerator.getRows();
-        PlayerSymbol[] symbols = horizontalRows[0].getSymbols();
+        List<Line> horizontalRows = lineGenerator.getRows();
+        PlayerSymbol[] symbols = horizontalRows.get(0).getSymbols();
         assertTrue(Arrays.equals(symbols, new PlayerSymbol[]{X, X, X, X}));
     }
 
@@ -167,12 +165,12 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT, VACANT,
                 VACANT, O, VACANT, VACANT
         );
-        Line[] rows = lineGenerator.getRows();
-        assertThat(rows.length, is(4));
-        Assert.assertThat(rows[0].getSymbols(), is(new PlayerSymbol[]{X, X, X, VACANT}));
-        Assert.assertThat(rows[1].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
-        Assert.assertThat(rows[2].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
-        Assert.assertThat(rows[3].getSymbols(), is(new PlayerSymbol[]{VACANT, O, VACANT, VACANT}));
+        List<Line> rows = lineGenerator.getRows();
+        assertThat(rows.size(), is(4));
+        assertThat(rows.get(0).getSymbols(), is(new PlayerSymbol[]{X, X, X, VACANT}));
+        assertThat(rows.get(1).getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
+        assertThat(rows.get(2).getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
+        assertThat(rows.get(3).getSymbols(), is(new PlayerSymbol[]{VACANT, O, VACANT, VACANT}));
     }
 
     @Test
@@ -183,18 +181,18 @@ public class LineGeneratorTest {
                 VACANT, VACANT, VACANT, O,
                 VACANT, O, VACANT, VACANT
         );
-        Line[] lines = lineGenerator.linesForAllDirections();
-        assertThat(lines.length, is(10));
+        List<Line> lines = lineGenerator.linesForAllDirections();
+        assertThat(lines.size(), is(10));
 
-        Assert.assertThat(lines[0].getSymbols(), is(new PlayerSymbol[]{X, X, X, VACANT}));
-        Assert.assertThat(lines[1].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
-        Assert.assertThat(lines[2].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, O}));
-        Assert.assertThat(lines[3].getSymbols(), is(new PlayerSymbol[]{VACANT, O, VACANT, VACANT}));
-        Assert.assertThat(lines[4].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, VACANT}));
-        Assert.assertThat(lines[5].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, O}));
-        Assert.assertThat(lines[6].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, VACANT}));
-        Assert.assertThat(lines[7].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, O, VACANT}));
-        Assert.assertThat(lines[8].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, VACANT}));
-        Assert.assertThat(lines[9].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
+        assertThat(lines.get(0).getSymbols(), is(new PlayerSymbol[]{X, X, X, VACANT}));
+        assertThat(lines.get(1).getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
+        assertThat(lines.get(2).getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, O}));
+        assertThat(lines.get(3).getSymbols(), is(new PlayerSymbol[]{VACANT, O, VACANT, VACANT}));
+        assertThat(lines.get(4).getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, VACANT}));
+        assertThat(lines.get(5).getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, O}));
+        assertThat(lines.get(6).getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, VACANT}));
+        assertThat(lines.get(7).getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, O, VACANT}));
+        assertThat(lines.get(8).getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, VACANT}));
+        assertThat(lines.get(9).getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
     }
 }

--- a/src/test/java/ttt/board/LineGeneratorTest.java
+++ b/src/test/java/ttt/board/LineGeneratorTest.java
@@ -1,5 +1,6 @@
 package ttt.board;
 
+import org.junit.Assert;
 import org.junit.Test;
 import ttt.player.PlayerSymbol;
 
@@ -61,14 +62,23 @@ public class LineGeneratorTest {
     }
 
     @Test
-    public void getsFourHorizontalRowsFor4x4() {
+    public void allLinesIn3x3() {
         LineGenerator lineGenerator = new LineGenerator(
-                X, X, X, VACANT,
-                VACANT, VACANT, VACANT, VACANT,
-                VACANT, VACANT, VACANT, VACANT,
-                VACANT, VACANT, VACANT, VACANT
+                X, X, X,
+                VACANT, VACANT, VACANT,
+                O, VACANT, VACANT
         );
-        assertThat(lineGenerator.getRows().length, is(4));
+        Line[] lines = lineGenerator.linesForAllDirections();
+        assertThat(lines.length, is(8));
+
+        Assert.assertThat(lines[0].getSymbols(), is(new PlayerSymbol[]{X, X, X}));
+        Assert.assertThat(lines[1].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT}));
+        Assert.assertThat(lines[2].getSymbols(), is(new PlayerSymbol[]{O, VACANT, VACANT}));
+        Assert.assertThat(lines[3].getSymbols(), is(new PlayerSymbol[]{X, VACANT, O}));
+        Assert.assertThat(lines[4].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT}));
+        Assert.assertThat(lines[5].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT}));
+        Assert.assertThat(lines[6].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT}));
+        Assert.assertThat(lines[7].getSymbols(), is(new PlayerSymbol[]{X, VACANT, O}));
     }
 
     @Test
@@ -136,16 +146,55 @@ public class LineGeneratorTest {
         assertTrue(rows[9].isWinning());
     }
 
+    @Test
+     public void symbolsOfLineIn4x4() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, X, X, X,
+                VACANT, VACANT, VACANT, O,
+                VACANT, VACANT, VACANT, O,
+                VACANT, VACANT, O, VACANT
+        );
+        Line[] horizontalRows = lineGenerator.getRows();
+        PlayerSymbol[] symbols = horizontalRows[0].getSymbols();
+        assertTrue(Arrays.equals(symbols, new PlayerSymbol[]{X, X, X, X}));
+    }
+
+    @Test
+    public void getsFourHorizontalRowsFor4x4() {
+        LineGenerator lineGenerator = new LineGenerator(
+                X, X, X, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, O, VACANT, VACANT
+        );
+        Line[] rows = lineGenerator.getRows();
+        assertThat(rows.length, is(4));
+        Assert.assertThat(rows[0].getSymbols(), is(new PlayerSymbol[]{X, X, X, VACANT}));
+        Assert.assertThat(rows[1].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
+        Assert.assertThat(rows[2].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
+        Assert.assertThat(rows[3].getSymbols(), is(new PlayerSymbol[]{VACANT, O, VACANT, VACANT}));
+    }
 
     @Test
     public void allLinesIn4x4() {
         LineGenerator lineGenerator = new LineGenerator(
                 X, X, X, VACANT,
                 VACANT, VACANT, VACANT, VACANT,
-                VACANT, VACANT, VACANT, VACANT,
-                VACANT, VACANT, VACANT, VACANT
+                VACANT, VACANT, VACANT, O,
+                VACANT, O, VACANT, VACANT
         );
-        assertThat(lineGenerator.linesForAllDirections().length, is(10));
-    }
+        Line[] lines = lineGenerator.linesForAllDirections();
+        assertThat(lines.length, is(10));
 
+        Assert.assertThat(lines[0].getSymbols(), is(new PlayerSymbol[]{X, X, X, VACANT}));
+        Assert.assertThat(lines[1].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
+        Assert.assertThat(lines[2].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, O}));
+        Assert.assertThat(lines[3].getSymbols(), is(new PlayerSymbol[]{VACANT, O, VACANT, VACANT}));
+        Assert.assertThat(lines[4].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, VACANT}));
+        Assert.assertThat(lines[5].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, O}));
+        Assert.assertThat(lines[6].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, VACANT}));
+        Assert.assertThat(lines[7].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, O, VACANT}));
+        Assert.assertThat(lines[8].getSymbols(), is(new PlayerSymbol[]{X, VACANT, VACANT, VACANT}));
+        Assert.assertThat(lines[9].getSymbols(), is(new PlayerSymbol[]{VACANT, VACANT, VACANT, VACANT}));
+    }
 }

--- a/src/test/java/ttt/inputvalidation/CompositeValidatorTest.java
+++ b/src/test/java/ttt/inputvalidation/CompositeValidatorTest.java
@@ -61,7 +61,7 @@ public class CompositeValidatorTest {
     public void inputNotValidatedIfOneOfSeveralValidationsFail() {
         List<InputValidator> validators = new ArrayList<>();
         validators.add(new NumericValidator());
-        validators.add(new WithinGridBoundaryValidator(new Board()));
+        validators.add(new WithinGridBoundaryValidator(new Board(3)));
         CompositeValidator compositeValidator = new CompositeValidator(validators);
 
         ValidationResult validationResult = compositeValidator.isValid("100");
@@ -73,7 +73,7 @@ public class CompositeValidatorTest {
     public void reasonForFailureReturnedWhenOneOfSeveralValidationsFails() {
         List<InputValidator> validators = new ArrayList<>();
         validators.add(new NumericValidator());
-        validators.add(new WithinGridBoundaryValidator(new Board()));
+        validators.add(new WithinGridBoundaryValidator(new Board(3)));
         CompositeValidator compositeValidator = new CompositeValidator(validators);
 
         ValidationResult validationResult = compositeValidator.isValid("100");
@@ -85,7 +85,7 @@ public class CompositeValidatorTest {
     public void inputValidatedIfAllValidationsAreSuccessfull() {
         List<InputValidator> validators = new ArrayList<>();
         validators.add(new NumericValidator());
-        validators.add(new WithinGridBoundaryValidator(new Board()));
+        validators.add(new WithinGridBoundaryValidator(new Board(3)));
         CompositeValidator compositeValidator = new CompositeValidator(validators);
 
         ValidationResult validationResult = compositeValidator.isValid("7");

--- a/src/test/java/ttt/inputvalidation/FreeSpaceOnBoardValidatorTest.java
+++ b/src/test/java/ttt/inputvalidation/FreeSpaceOnBoardValidatorTest.java
@@ -22,7 +22,7 @@ public class FreeSpaceOnBoardValidatorTest {
 
     @Test
     public void returnsTrueIfSpaceOnBoardIsVacant() {
-        Board board = new Board();
+        Board board = new Board(3);
         FreeSpaceOnBoardValidator freeSpaceOnBoardValidator = new FreeSpaceOnBoardValidator(board);
 
         ValidationResult validationResult = freeSpaceOnBoardValidator.isValid("1");

--- a/src/test/java/ttt/inputvalidation/ReplayOptionValidatorTest.java
+++ b/src/test/java/ttt/inputvalidation/ReplayOptionValidatorTest.java
@@ -35,4 +35,11 @@ public class ReplayOptionValidatorTest {
         assertThat(validator.isValid("P").reason(), is("[P] is not a valid replay option"));
     }
 
+    @Test
+    public void replayOptionOfLowerCaseYReturnsTrue() {
+        InputValidator validator = new ReplayOptionValidator();
+
+        assertTrue(validator.isValid("y").isValid());
+    }
+
 }

--- a/src/test/java/ttt/inputvalidation/WithinGivenRangeValidatorTest.java
+++ b/src/test/java/ttt/inputvalidation/WithinGivenRangeValidatorTest.java
@@ -1,0 +1,37 @@
+package ttt.inputvalidation;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class WithinGivenRangeValidatorTest {
+
+    @Test
+    public void withinBoundary() {
+        WithinGivenRangeValidator lessThanValue = new WithinGivenRangeValidator(10);
+
+        ValidationResult validationResult = lessThanValue.isValid("1");
+        assertThat(validationResult.isValid(), is(true));
+        assertThat(validationResult.reason(), is(""));
+    }
+
+    @Test
+    public void outsideOfLowerBoundary() {
+        WithinGivenRangeValidator lessThanValue = new WithinGivenRangeValidator(10);
+
+        ValidationResult validationResult = lessThanValue.isValid("-1");
+        assertThat(validationResult.isValid(), is(false));
+        assertThat(validationResult.reason(), is("[-1] is outside of the range 1 to 10"));
+    }
+
+    @Test
+    public void largerThanUpperBoundary() {
+        WithinGivenRangeValidator lessThanValue = new WithinGivenRangeValidator(10);
+
+        ValidationResult validationResult = lessThanValue.isValid("100");
+        assertThat(validationResult.isValid(), is(false));
+        assertThat(validationResult.reason(), is("[100] is outside of the range 1 to 10"));
+
+    }
+}

--- a/src/test/java/ttt/inputvalidation/WithinGridBoundaryValidatorTest.java
+++ b/src/test/java/ttt/inputvalidation/WithinGridBoundaryValidatorTest.java
@@ -10,7 +10,7 @@ public class WithinGridBoundaryValidatorTest {
 
     @Test
     public void evaluatesFalseIfInputIsWithinGridBoundary() {
-        WithinGridBoundaryValidator gridBoundaryValidator = new WithinGridBoundaryValidator(new Board());
+        WithinGridBoundaryValidator gridBoundaryValidator = new WithinGridBoundaryValidator(new Board(3));
 
         ValidationResult validationResult = gridBoundaryValidator.isValid("100");
 
@@ -19,7 +19,7 @@ public class WithinGridBoundaryValidatorTest {
 
     @Test
     public void evaluatesTrueIfInputIsWithinGridBoundary() {
-        WithinGridBoundaryValidator gridBoundaryValidator = new WithinGridBoundaryValidator(new Board());
+        WithinGridBoundaryValidator gridBoundaryValidator = new WithinGridBoundaryValidator(new Board(3));
 
         ValidationResult validationResult = gridBoundaryValidator.isValid("1");
 
@@ -28,7 +28,7 @@ public class WithinGridBoundaryValidatorTest {
 
     @Test
     public void informativeMethodReturnedWhenInputIsValid() {
-        WithinGridBoundaryValidator gridBoundaryValidator = new WithinGridBoundaryValidator(new Board());
+        WithinGridBoundaryValidator gridBoundaryValidator = new WithinGridBoundaryValidator(new Board(3));
 
         ValidationResult validationResult = gridBoundaryValidator.isValid("-1");
 

--- a/src/test/java/ttt/player/DelayedUnbeatablePlayerTest.java
+++ b/src/test/java/ttt/player/DelayedUnbeatablePlayerTest.java
@@ -1,0 +1,298 @@
+package ttt.player;
+
+import org.junit.Test;
+import ttt.board.Board;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static ttt.player.PlayerSymbol.O;
+import static ttt.player.PlayerSymbol.VACANT;
+import static ttt.player.PlayerSymbol.X;
+
+public class DelayedUnbeatablePlayerTest {
+
+    @Test
+    public void takesFirstVacantPositionFromEmptyBoard() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(new Board(4)), is(0));
+    }
+
+    @Test
+    public void takesFirstVacantPositionFromBoardWithTwoPositionsTaken() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                X, O, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(2));
+    }
+
+    @Test
+    public void takesWinningMoveInFirstRow() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                X, X, X, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                O, O, O, VACANT,
+                VACANT, VACANT, VACANT, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(3));
+    }
+
+    @Test
+    public void takesWinningMoveInSecondRow() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, X, X, X,
+                O, O, O, VACANT,
+                VACANT, VACANT, VACANT, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(4));
+    }
+
+    @Test
+
+    public void takesWinningMoveInThirdRow() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, VACANT, VACANT, VACANT,
+                O, O, O, VACANT,
+                VACANT, X, X, X,
+                VACANT, VACANT, VACANT, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(8));
+    }
+
+    @Test
+    public void takesWinningMoveInFourthRow() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, VACANT, VACANT, VACANT,
+                O, O, O, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                X, X, VACANT, X
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(14));
+    }
+
+    @Test
+    public void takesWinningMoveInFirstColumn() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                X, VACANT, VACANT, VACANT,
+                X, VACANT, VACANT, VACANT,
+                VACANT, O, O, VACANT,
+                X, VACANT, VACANT, O
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(8));
+    }
+
+
+    @Test
+    public void takesWinningMoveInSecondColumn() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, X, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, X, O, VACANT,
+                O, X, VACANT, O
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(5));
+    }
+
+
+    @Test
+    public void takesWinningMoveInThirdColumn() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, VACANT, X, VACANT,
+                VACANT, VACANT, X, VACANT,
+                VACANT, O, X, VACANT,
+                O, O, VACANT, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(14));
+    }
+
+    @Test
+    public void takesWinningMoveInFourthColumn() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, X,
+                VACANT, O, VACANT, X,
+                O, O, VACANT, X
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(3));
+    }
+
+    @Test
+    public void takesWinningMoveInForwardDiagonal() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, VACANT, VACANT, X,
+                VACANT, VACANT, X, VACANT,
+                VACANT, X, O, VACANT,
+                VACANT, O, O, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(12));
+    }
+
+    @Test
+    public void takesWinningMoveInBackwardsDiagonal() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                X, VACANT, VACANT, VACANT,
+                VACANT, X, VACANT, VACANT,
+                VACANT, O, X, VACANT,
+                VACANT, O, O, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(15));
+    }
+
+    @Test
+    public void blocksOpponentsWinInFirstRow() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                O, O, O, VACANT,
+                VACANT, X, VACANT, VACANT,
+                VACANT, X, X, VACANT,
+                VACANT, VACANT, VACANT, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(3));
+    }
+
+    @Test
+    public void blocksOpponentsWinInSecondRow() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, X, VACANT, VACANT,
+                O, O, VACANT, O,
+                VACANT, X, X, VACANT,
+                VACANT, VACANT, VACANT, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(6));
+    }
+
+    @Test
+    public void blocksOpponentsWinInThirdRow() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, X, X, O,
+                VACANT, X, X, VACANT,
+                O, VACANT, O, O,
+                VACANT, VACANT, VACANT, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(9));
+    }
+
+    @Test
+    public void blocksOpponentsWinInFourthRow() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, X, X, O,
+                VACANT, X, X, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                O, VACANT, O, O
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(13));
+    }
+
+
+    @Test
+    public void blocksOpponentWinInFirstColumn() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                O, X, X, VACANT,
+                O, VACANT, X, VACANT,
+                VACANT, VACANT, O, VACANT,
+                O, X, VACANT, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(8));
+    }
+
+
+    @Test
+    public void blocksOpponentsWinInThirdColumn() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, VACANT, O, VACANT,
+                VACANT, X, O, VACANT,
+                VACANT, X, O, VACANT,
+                X, VACANT, VACANT, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(14));
+    }
+
+    @Test
+    public void blocksOpponentsWinInFourthColumn() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, VACANT, VACANT, O,
+                VACANT, VACANT, VACANT, O,
+                VACANT, X, VACANT, VACANT,
+                X, X, VACANT, O
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(11));
+    }
+
+    @Test
+    public void blocksOpponentsWinInForwardDiagonal() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, VACANT, VACANT, O,
+                VACANT, VACANT, O, VACANT,
+                VACANT, O, X, VACANT,
+                VACANT, X, X, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(12));
+    }
+
+    @Test
+    public void blocksOpponentsWinInBackwardsDiagonal() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, O, VACANT, VACANT,
+                VACANT, X, O, VACANT,
+                VACANT, X, X, O
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(0));
+    }
+
+    @Test
+    public void blocksOpponentWhenUnbeatableDoesNotOpenTheGame() {
+        DelayedUnbeatablePlayer delayedUnbeatablePlayer = new DelayedUnbeatablePlayer(X, new UnbeatablePlayer(X));
+
+        Board board = new Board(
+                X, X, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, VACANT,
+                O, O, O, VACANT
+        );
+        assertThat(delayedUnbeatablePlayer.chooseNextMoveFrom(board), is(15));
+    }
+}

--- a/src/test/java/ttt/player/PlayerFactoryTest.java
+++ b/src/test/java/ttt/player/PlayerFactoryTest.java
@@ -13,13 +13,12 @@ import static org.junit.Assert.assertThat;
 import static ttt.GameType.*;
 
 public class PlayerFactoryTest {
-
     @Test
     public void createsHumanPlayers() {
         PlayerFactory playerFactory = new PlayerFactory();
         Prompt commandPrompt = new CommandPrompt(new StringReader(""), new StringWriter());
 
-        Player[] player = playerFactory.createPlayers(HUMAN_VS_HUMAN, commandPrompt);
+        Player[] player = playerFactory.createPlayers(HUMAN_VS_HUMAN, commandPrompt, 3);
 
         assertThat(player.length, is(2));
         assertThat(player[0], instanceOf(HumanPlayer.class));
@@ -27,11 +26,11 @@ public class PlayerFactoryTest {
     }
 
     @Test
-    public void createsHumanAndUnbeatablePlayer() {
+    public void createsHumanAndUnbeatablePlayerFor3x3() {
         PlayerFactory playerFactory = new PlayerFactory();
         Prompt commandPrompt = new CommandPrompt(new StringReader(""), new StringWriter());
 
-        Player[] player = playerFactory.createPlayers(HUMAN_VS_UNBEATABLE, commandPrompt);
+        Player[] player = playerFactory.createPlayers(HUMAN_VS_UNBEATABLE, commandPrompt, 3);
 
         assertThat(player.length, is(2));
         assertThat(player[0], instanceOf(HumanPlayer.class));
@@ -39,14 +38,26 @@ public class PlayerFactoryTest {
     }
 
     @Test
-    public void createsUnbeatableAndHumanPlayer() {
+    public void createsUnbeatableAndHumanPlayerFor3x3() {
         PlayerFactory playerFactory = new PlayerFactory();
         Prompt commandPrompt = new CommandPrompt(new StringReader(""), new StringWriter());
 
-        Player[] player = playerFactory.createPlayers(UNBEATABLE_VS_HUMAN, commandPrompt);
+        Player[] player = playerFactory.createPlayers(UNBEATABLE_VS_HUMAN, commandPrompt, 3);
 
         assertThat(player.length, is(2));
         assertThat(player[0], instanceOf(UnbeatablePlayer.class));
+        assertThat(player[1], instanceOf(HumanPlayer.class));
+    }
+
+    @Test
+    public void createsUnbeatableAndHumanFor4x4() {
+        PlayerFactory playerFactory = new PlayerFactory();
+        Prompt commandPrompt = new CommandPrompt(new StringReader(""), new StringWriter());
+
+        Player[] player = playerFactory.createPlayers(UNBEATABLE_VS_HUMAN, commandPrompt, 4);
+
+        assertThat(player.length, is(2));
+        assertThat(player[0], instanceOf(DelayedUnbeatablePlayer.class));
         assertThat(player[1], instanceOf(HumanPlayer.class));
     }
 }

--- a/src/test/java/ttt/player/UnbeatablePlayerTest.java
+++ b/src/test/java/ttt/player/UnbeatablePlayerTest.java
@@ -17,7 +17,7 @@ public class UnbeatablePlayerTest {
                 O, VACANT, VACANT
         );
 
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(0));
     }
@@ -30,7 +30,7 @@ public class UnbeatablePlayerTest {
                 O, VACANT, O
         );
 
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(5));
     }
@@ -42,7 +42,7 @@ public class UnbeatablePlayerTest {
                 VACANT, O, VACANT,
                 X, VACANT, X
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(7));
     }
@@ -54,7 +54,7 @@ public class UnbeatablePlayerTest {
                 X, VACANT, O,
                 VACANT, VACANT, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(6));
     }
@@ -65,7 +65,7 @@ public class UnbeatablePlayerTest {
                 VACANT, X, VACANT,
                 O, VACANT, O,
                 VACANT, X, VACANT);
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(4));
     }
@@ -77,7 +77,7 @@ public class UnbeatablePlayerTest {
                 O, VACANT, X,
                 VACANT, O, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(8));
     }
@@ -90,7 +90,7 @@ public class UnbeatablePlayerTest {
                 O, VACANT, O,
                 X, VACANT, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(4));
     }
@@ -102,7 +102,7 @@ public class UnbeatablePlayerTest {
                 O, X, O,
                 VACANT, VACANT, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(8));
     }
@@ -114,7 +114,7 @@ public class UnbeatablePlayerTest {
                 VACANT, VACANT, O,
                 VACANT, VACANT, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(8));
     }
@@ -126,7 +126,7 @@ public class UnbeatablePlayerTest {
                 VACANT, O, X,
                 VACANT, O, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(1));
     }
@@ -138,7 +138,7 @@ public class UnbeatablePlayerTest {
                 VACANT, VACANT, X,
                 O, X, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(3));
     }
@@ -150,7 +150,7 @@ public class UnbeatablePlayerTest {
                 X, VACANT, VACANT,
                 VACANT, X, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(1));
     }
@@ -161,7 +161,7 @@ public class UnbeatablePlayerTest {
                 VACANT, VACANT, X,
                 VACANT, VACANT, X,
                 O, VACANT, O);
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(7));
     }
@@ -173,7 +173,7 @@ public class UnbeatablePlayerTest {
                 O, O, VACANT,
                 X, VACANT, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(5));
     }
@@ -185,7 +185,7 @@ public class UnbeatablePlayerTest {
                 VACANT, VACANT, VACANT,
                 VACANT, VACANT, O
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(4));
     }
@@ -197,7 +197,7 @@ public class UnbeatablePlayerTest {
                 VACANT, O, VACANT,
                 O, X, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(2));
     }
@@ -209,7 +209,7 @@ public class UnbeatablePlayerTest {
                 VACANT, X, VACANT,
                 VACANT, VACANT, O
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(1));
     }
@@ -221,8 +221,19 @@ public class UnbeatablePlayerTest {
                 VACANT, VACANT, O,
                 VACANT, VACANT, VACANT
         );
-        UnbeatablePlayer player = new UnbeatablePlayer(X);
+        Player player = new UnbeatablePlayer(X);
 
         assertThat(player.chooseNextMoveFrom(board), is(6));
+    }
+
+    @Test
+    public void takesFirstMoveIn3x3Grid() {
+        Board board = new Board(
+                VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT
+        );
+        Player player = new UnbeatablePlayer(X);
+        assertThat(player.chooseNextMoveFrom(board), is(0));
     }
 }

--- a/src/test/java/ttt/ui/CommandPromptTest.java
+++ b/src/test/java/ttt/ui/CommandPromptTest.java
@@ -15,6 +15,7 @@ import java.io.Writer;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static ttt.GameType.*;
 import static ttt.GameType.HUMAN_VS_HUMAN;
 import static ttt.ReplayOption.Y;
 import static ttt.player.PlayerSymbol.*;
@@ -45,9 +46,9 @@ public class CommandPromptTest {
         StringWriter writer = new StringWriter();
         Prompt prompt = new CommandPrompt(new StringReader("1\n"), writer);
 
-        prompt.getBoardDimension();
+        prompt.getBoardDimension(HUMAN_VS_HUMAN);
 
-        assertThat(writer.toString().contains("Please enter the dimension of the board you would like to use\n"), is(true));
+        assertThat(writer.toString().contains("Please enter the dimension of the board you would like to use [1 to 10]\n"), is(true));
     }
 
     @Test
@@ -55,7 +56,7 @@ public class CommandPromptTest {
         StringReader reader = new StringReader("3\n");
         Prompt prompt = new CommandPrompt(reader, new StringWriter());
 
-        int dimension = prompt.getBoardDimension();
+        int dimension = prompt.getBoardDimension(HUMAN_VS_HUMAN);
 
         assertThat(dimension, is(3));
     }
@@ -66,15 +67,33 @@ public class CommandPromptTest {
         StringWriter writer = new StringWriter();
         Prompt prompt = new CommandPrompt(reader, writer);
 
-        int dimension = prompt.getBoardDimension();
+        int dimension = prompt.getBoardDimension(HUMAN_VS_HUMAN);
 
         assertThat(dimension, is(4));
         assertThat(writer.toString().contains(
                           BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS
                         + Z_IS_NOT_A_VALID_INTEGER
                         + FONT_COLOUR_ANSII_CHARACTERS
-                        + "Please enter the dimension of the board you would like to use\n\n"
+                        + "Please enter the dimension of the board you would like to use [1 to 10]\n\n"
                                   + CLEAR_SCREEN_ANSI_CHARACTERS + "\n"), is(true));
+    }
+
+
+    @Test
+    public void repromptsUserWhenInvalidDimensionEnteredForGameType() {
+        StringReader reader = new StringReader("100\n4\n");
+        StringWriter writer = new StringWriter();
+        Prompt prompt = new CommandPrompt(reader, writer);
+
+        int dimension = prompt.getBoardDimension(HUMAN_VS_UNBEATABLE);
+
+        assertThat(dimension, is(4));
+        assertThat(writer.toString().contains(
+                BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS
+                        + "[100] is outside of the range 1 to 4\n\n"
+                        + FONT_COLOUR_ANSII_CHARACTERS
+                        + "Please enter the dimension of the board you would like to use [1 to 4]\n\n"
+                        + CLEAR_SCREEN_ANSI_CHARACTERS + "\n"), is(true));
     }
 
     @Test
@@ -84,7 +103,7 @@ public class CommandPromptTest {
 
         prompt.getNextMove(new Board(3));
 
-        assertThat(writer.toString().contains(vacantBoard()), is(true));
+        assertThat(writer.toString().contains(vacant3x3Board()), is(true));
     }
 
     @Test
@@ -94,7 +113,7 @@ public class CommandPromptTest {
 
         prompt.getNextMove(new Board(3));
 
-        assertThat(writer.toString().endsWith("\n" + CLEAR_SCREEN_ANSI_CHARACTERS + vacantBoard() + "\n" + A_IS_NOT_A_NUMBER_REPROMPT + "\n\n" + CLEAR_SCREEN_ANSI_CHARACTERS + "\n"), is(true));
+        assertThat(writer.toString().endsWith("\n" + CLEAR_SCREEN_ANSI_CHARACTERS + vacant3x3Board() + "\n" + A_IS_NOT_A_NUMBER_REPROMPT + "\n\n" + CLEAR_SCREEN_ANSI_CHARACTERS + "\n"), is(true));
     }
 
     @Test
@@ -261,20 +280,33 @@ public class CommandPromptTest {
 
 
     @Test
-    public void printsNewBoard() {
+    public void printsNew3x3Board() {
         Board board = new Board(3);
         StringWriter writer = new StringWriter();
         Prompt prompt = new CommandPrompt(new StringReader(""), writer);
 
         prompt.print(board);
 
-        String formattedGrid = vacantBoard();
+        String formattedGrid = vacant3x3Board();
 
         assertThat(writer.toString(), is("\n" + CLEAR_SCREEN_ANSI_CHARACTERS + formattedGrid));
     }
 
     @Test
-    public void printsBoardWithMoves() {
+    public void printsNew4x4Board() {
+        Board board = new Board(4);
+        StringWriter writer = new StringWriter();
+        Prompt prompt = new CommandPrompt(new StringReader(""), writer);
+
+        prompt.print(board);
+
+        String formattedGrid = vacant4x4Board();
+
+        assertThat(writer.toString(), is("\n" + CLEAR_SCREEN_ANSI_CHARACTERS + formattedGrid));
+    }
+
+    @Test
+    public void prints3x3BoardWithMoves() {
         Board board = new Board(VACANT, X, X, O, VACANT, VACANT, VACANT, VACANT, VACANT);
 
         StringWriter writer = new StringWriter();
@@ -282,12 +314,37 @@ public class CommandPromptTest {
 
         prompt.print(board);
 
-        assertThat(writer.toString(), is("\n" + CLEAR_SCREEN_ANSI_CHARACTERS + "\n\n" + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + "\n "
-                + NUMBER_COLOUR_ANSII_CHARACTERS + 1 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + X_COLOUR + X.name() + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + X_COLOUR + X.name() + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
-                + "-----------\n "
-                + O_COLOUR + O.name() + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 5 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 6 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
-                + "-----------\n "
-                + NUMBER_COLOUR_ANSII_CHARACTERS + 7 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 8 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 9 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"));
+        assertThat(writer.toString(), is("\n" + CLEAR_SCREEN_ANSI_CHARACTERS + "\n\n" + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + "\n  "
+                + NUMBER_COLOUR_ANSII_CHARACTERS + 1 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + X_COLOUR + X.name() + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + X_COLOUR + X.name() + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
+                + "---------------\n  "
+                + O_COLOUR + O.name() + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 5 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 6 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
+                + "---------------\n  "
+                + NUMBER_COLOUR_ANSII_CHARACTERS + 7 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 8 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 9 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"));
+    }
+
+    @Test
+    public void prints4x4BoardWithMoves() {
+        Board board = new Board(
+                VACANT, VACANT, VACANT, VACANT,
+                O, VACANT, VACANT, VACANT,
+                VACANT, VACANT, VACANT, X,
+                VACANT, VACANT, VACANT, VACANT);
+
+        StringWriter writer = new StringWriter();
+        Prompt prompt = new CommandPrompt(new StringReader(""), writer);
+
+        prompt.print(board);
+
+        String expectedFormattedBoard =
+                 "  " + NUMBER_COLOUR_ANSII_CHARACTERS + 1 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 2 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 3 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 4 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
+                + "--------------------\n  "
+                + O_COLOUR + O.name() + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 6 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 7 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 8 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
+                + "--------------------\n  "
+                + NUMBER_COLOUR_ANSII_CHARACTERS + 9 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 10 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 11 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + X_COLOUR + X.name() + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
+                + "--------------------\n "
+                + NUMBER_COLOUR_ANSII_CHARACTERS + 13 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 14 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 15 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 16 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n";
+
+        assertThat(writer.toString(), is("\n" + CLEAR_SCREEN_ANSI_CHARACTERS + "\n\n" + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + "\n"  + expectedFormattedBoard));
     }
 
     @Test
@@ -378,12 +435,23 @@ public class CommandPromptTest {
         promptWhichHasExceptionOnRead.getReplayOption();
     }
 
-    private String vacantBoard() {
-        return "\n\n" + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + "\n "
-                + NUMBER_COLOUR_ANSII_CHARACTERS + 1 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 2 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 3 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
-                + "-----------\n "
-                + NUMBER_COLOUR_ANSII_CHARACTERS + 4 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 5 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 6 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
-                + "-----------\n "
-                + NUMBER_COLOUR_ANSII_CHARACTERS + 7 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 8 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 9 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n";
+    private String vacant3x3Board() {
+        return "\n\n" + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + "\n  "
+                + NUMBER_COLOUR_ANSII_CHARACTERS + 1 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 2 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 3 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
+                + "---------------\n "
+                + " " + NUMBER_COLOUR_ANSII_CHARACTERS + 4 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 5 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 6 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
+                + "---------------\n "
+                + " " + NUMBER_COLOUR_ANSII_CHARACTERS + 7 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 8 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 9 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n";
+    }
+
+    private String vacant4x4Board() {
+        return "\n\n" + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + "\n  "
+                + NUMBER_COLOUR_ANSII_CHARACTERS + 1 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 2 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 3 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 4 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
+                + "--------------------\n  "
+                + NUMBER_COLOUR_ANSII_CHARACTERS + 5 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 6 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 7 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " |  " + NUMBER_COLOUR_ANSII_CHARACTERS + 8 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
+                + "--------------------\n  "
+                + NUMBER_COLOUR_ANSII_CHARACTERS + 9 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 10 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 11 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 12 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n"
+                + "--------------------\n "
+                + NUMBER_COLOUR_ANSII_CHARACTERS + 13 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 14 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 15 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " | " + NUMBER_COLOUR_ANSII_CHARACTERS + 16 + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + " \n";
     }
 }

--- a/src/test/java/ttt/ui/CommandPromptTest.java
+++ b/src/test/java/ttt/ui/CommandPromptTest.java
@@ -32,7 +32,8 @@ public class CommandPromptTest {
     private static final String NEXT_MOVE_PROMPT = "Please enter the index for your next move";
     private static final String A_IS_NOT_A_VALID_NUMBER = "[a] is not a valid integer\n\n";
     private static final String A_IS_NOT_A_NUMBER_REPROMPT = A_IS_NOT_A_VALID_NUMBER + FONT_COLOUR_ANSII_CHARACTERS + NEXT_MOVE_PROMPT;
-    private static final String Z_IS_NOT_A_NUMBER = "[z] is not a valid integer\n\n" + FONT_COLOUR_ANSII_CHARACTERS + NEXT_MOVE_PROMPT;
+    public static final String Z_IS_NOT_A_VALID_INTEGER = "[z] is not a valid integer\n\n";
+    private static final String Z_IS_NOT_A_NUMBER_MOVE_REPROMPT = Z_IS_NOT_A_VALID_INTEGER + FONT_COLOUR_ANSII_CHARACTERS + NEXT_MOVE_PROMPT;
     private static final String DRAW_MESSAGE = "No winner this time";
     private static final String A_IS_NOT_REPLAY_OPTION = "[A] is not a valid replay option\n\n" + FONT_COLOUR_ANSII_CHARACTERS + PLAY_AGAIN_PROMPT;
     private static final String ALREADY_OCCUPIED_CELL_MESSAGE = "[1] is already occupied\n\n" + FONT_COLOUR_ANSII_CHARACTERS + NEXT_MOVE_PROMPT;
@@ -40,11 +41,48 @@ public class CommandPromptTest {
     private static final String SMALLER_THAN_GRID_BOUNDARY_MESSAGE = "[-100] is outside of the grid boundary\n\n" + FONT_COLOUR_ANSII_CHARACTERS + NEXT_MOVE_PROMPT;
 
     @Test
+    public void promptsUserForBoardDimension() {
+        StringWriter writer = new StringWriter();
+        Prompt prompt = new CommandPrompt(new StringReader("1\n"), writer);
+
+        prompt.getBoardDimension();
+
+        assertThat(writer.toString().contains("Please enter the dimension of the board you would like to use\n"), is(true));
+    }
+
+    @Test
+    public void readsDimensionFromCommandLine() {
+        StringReader reader = new StringReader("3\n");
+        Prompt prompt = new CommandPrompt(reader, new StringWriter());
+
+        int dimension = prompt.getBoardDimension();
+
+        assertThat(dimension, is(3));
+    }
+
+    @Test
+    public void repromptsUserWhenNonNumericEnteredForBoardDimension() {
+        StringReader reader = new StringReader("z\n4\n");
+        StringWriter writer = new StringWriter();
+        Prompt prompt = new CommandPrompt(reader, writer);
+
+        int dimension = prompt.getBoardDimension();
+
+        assertThat(dimension, is(4));
+        assertThat(writer.toString().contains(
+                          BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS
+                        + Z_IS_NOT_A_VALID_INTEGER
+                        + FONT_COLOUR_ANSII_CHARACTERS
+                        + "Please enter the dimension of the board you would like to use\n\n"
+                                  + CLEAR_SCREEN_ANSI_CHARACTERS + "\n"), is(true));
+    }
+
+    @Test
     public void displaysBoardWhenPromptingForNextMove() {
         StringWriter writer = new StringWriter();
         Prompt prompt = new CommandPrompt(new StringReader("1\n"), writer);
 
-        prompt.getNextMove(new Board());
+        prompt.getNextMove(new Board(3));
 
         assertThat(writer.toString().contains(vacantBoard()), is(true));
     }
@@ -54,7 +92,7 @@ public class CommandPromptTest {
         StringWriter writer = new StringWriter();
         Prompt prompt = new CommandPrompt(new StringReader("a\n1\n"), writer);
 
-        prompt.getNextMove(new Board());
+        prompt.getNextMove(new Board(3));
 
         assertThat(writer.toString().endsWith("\n" + CLEAR_SCREEN_ANSI_CHARACTERS + vacantBoard() + "\n" + A_IS_NOT_A_NUMBER_REPROMPT + "\n\n" + CLEAR_SCREEN_ANSI_CHARACTERS + "\n"), is(true));
     }
@@ -64,7 +102,7 @@ public class CommandPromptTest {
         StringWriter writer = new StringWriter();
         Prompt prompt = new CommandPrompt(new StringReader("1\n"), writer);
 
-        prompt.getNextMove(new Board());
+        prompt.getNextMove(new Board(3));
 
         assertThat(writer.toString().endsWith(CLEAR_SCREEN_ANSI_CHARACTERS + "\n"), is(true));
     }
@@ -74,7 +112,7 @@ public class CommandPromptTest {
         StringReader reader = new StringReader("1\n");
         Prompt prompt = new CommandPrompt(reader, new StringWriter());
 
-        assertThat(prompt.getNextMove(new Board()), equalTo(0));
+        assertThat(prompt.getNextMove(new Board(3)), equalTo(0));
     }
 
     @Test
@@ -83,9 +121,9 @@ public class CommandPromptTest {
         StringWriter writer = new StringWriter();
         Prompt prompt = new CommandPrompt(reader, writer);
 
-        assertThat(prompt.getNextMove(new Board()), equalTo(0));
+        assertThat(prompt.getNextMove(new Board(3)), equalTo(0));
         assertThat(writer.toString().contains(A_IS_NOT_A_NUMBER_REPROMPT), is(true));
-        assertThat(writer.toString().contains(Z_IS_NOT_A_NUMBER), is(true));
+        assertThat(writer.toString().contains(Z_IS_NOT_A_NUMBER_MOVE_REPROMPT), is(true));
     }
 
     @Test
@@ -94,7 +132,7 @@ public class CommandPromptTest {
         StringWriter writer = new StringWriter();
         Prompt prompt = new CommandPrompt(reader, writer);
 
-        assertThat(prompt.getNextMove(new Board()), equalTo(0));
+        assertThat(prompt.getNextMove(new Board(3)), equalTo(0));
 
         assertThat(writer.toString().contains(LARGER_THAN_GRID_BOUNDARY_MESSAGE), is(true));
         assertThat(writer.toString().contains(SMALLER_THAN_GRID_BOUNDARY_MESSAGE), is(true));
@@ -224,7 +262,7 @@ public class CommandPromptTest {
 
     @Test
     public void printsNewBoard() {
-        Board board = new Board();
+        Board board = new Board(3);
         StringWriter writer = new StringWriter();
         Prompt prompt = new CommandPrompt(new StringReader(""), writer);
 
@@ -287,7 +325,7 @@ public class CommandPromptTest {
         Writer writer = new StringWriter();
         Prompt commandPrompt = new CommandPrompt(new StringReader("1\n"), writer);
 
-        commandPrompt.getNextMove(new Board());
+        commandPrompt.getNextMove(new Board(3));
 
         assertThat(writer.toString().contains(FONT_COLOUR_ANSII_CHARACTERS + NEXT_MOVE_PROMPT + "\n"), is(true));
     }
@@ -296,7 +334,7 @@ public class CommandPromptTest {
     public void setsFontColourWhenPrintingGrid() {
         Writer writer = new StringWriter();
         Prompt commandPrompt = new CommandPrompt(new StringReader(""), writer);
-        commandPrompt.print(new Board());
+        commandPrompt.print(new Board(3));
 
         assertThat(writer.toString().startsWith("\n" + CLEAR_SCREEN_ANSI_CHARACTERS + "\n\n" + BOARD_OUTLINE_COLOUR_ANSII_CHARACTERS + "\n"), is(true));
     }


### PR DESCRIPTION
@ecomba, @jsuchy, here is the pull request for making the game support a 4x4 board. 

It includes the following:-
- Allows the user to specify a dimension for the board - which has different boundaries depending on the game type (i.e.: Human vs Human allows a range up to 10x10, whereas the combinations with computer player go up to 4x4).
- Validates the dimension entered by the user, to ensure its a number within the given range
- The logic to work out all the ‘lines’ on a board has been generalised, so would now work with any size grid.
- Display of the grid updated to ensure that when the grid is large and has both single and double digit indexes, it still presents in straight aligned lines.
- Introduces `DelayedUnbeatablePlayer` which plants its first two moves without using the minimax algorithm. The minimax algorithm will kick in once 4 moves on the board have been made (as that is the first time you need to be smart and potentially block the opponents win).
- BoardFactory introduced to the Game to create a board with the given dimension.
- Unbeatable test updated to include tests for 4x4 grid.

Note: 
Some of the 4x4 tests are a little slow. 
Additionally whilst the user is unbeatable for 4x4 grid, for the game type: Human vs Computer, the 5th move (when minimax kicks in) is noticeably slow, so this has degraded the user experience. 

@jsuchy has asked I move onto a new task and think about what I would do as next steps to mitigate this. I’ll come with some ideas to Tuesday’s IPM.
