### PR TITLE
Reinitialises the player index on replay

### DIFF
--- a/src/main/java/ttt/CommandLineGameController.java
+++ b/src/main/java/ttt/CommandLineGameController.java
@@ -89,7 +89,7 @@ public class CommandLineGameController {
         while (gameInProgress()) {
             updateBoardWithPlayersMove();
         }
-        displayResultsOfGame();
+        printExitMessage();
     }
 
     private ReplayOption getReplayOptionFromPlayer() {
@@ -112,16 +112,12 @@ public class CommandLineGameController {
         return gameRules.gameInProgress();
     }
 
-    void displayResultsOfGame() {
-        printExitMessage();
-    }
-
     GameType getGameType() {
         return gameType;
     }
 
-    private void printExitMessage() {
-        if (!gameRules.hasWinner()) {
+    void printExitMessage() {
+        if (gameRules.noWinnerYet()) {
             gamePrompt.printsDrawMessage(gameRules.getBoard());
         } else {
             gamePrompt.printsWinningMessage(gameRules.getBoard(), gameRules.getWinningSymbol());

--- a/src/main/java/ttt/gui/GameRules.java
+++ b/src/main/java/ttt/gui/GameRules.java
@@ -9,6 +9,7 @@ public interface GameRules {
     void takeTurn(int move);
     PlayerSymbol getWinningSymbol();
     boolean hasWinner();
+    boolean noWinnerYet();
     Board getBoard();
     boolean gameInProgress();
     boolean boardHasFreeSpace();

--- a/src/main/java/ttt/gui/TicTacToeRules.java
+++ b/src/main/java/ttt/gui/TicTacToeRules.java
@@ -31,6 +31,7 @@ public class TicTacToeRules implements GameRules {
         Integer boardDimension = Integer.valueOf(dimension);
         board = boardFactory.createBoardWithSize(boardDimension);
         players = playerFactory.createPlayers(gameType, boardDimension);
+        currentPlayerIndex = PLAYER_ONE_INDEX;
     }
 
     @Override
@@ -64,7 +65,7 @@ public class TicTacToeRules implements GameRules {
         return board.hasWinningCombination();
     }
 
-   private void togglePlayer() {
+    private void togglePlayer() {
         currentPlayerIndex =
                 currentPlayerIndex == PLAYER_ONE_INDEX
                         ? PLAYER_TWO_INDEX
@@ -72,10 +73,10 @@ public class TicTacToeRules implements GameRules {
     }
 
 
-   @Override
-   public boolean gameInProgress() {
-      return boardHasFreeSpace() && !hasWinner();
-   }
+    @Override
+    public boolean gameInProgress() {
+        return boardHasFreeSpace() && !hasWinner();
+    }
 
     int getCurrentPlayerIndex() {
         return currentPlayerIndex;

--- a/src/main/java/ttt/gui/TicTacToeRules.java
+++ b/src/main/java/ttt/gui/TicTacToeRules.java
@@ -65,20 +65,25 @@ public class TicTacToeRules implements GameRules {
         return board.hasWinningCombination();
     }
 
+    @Override
+    public boolean noWinnerYet() {
+        return !hasWinner();
+    }
+
+    @Override
+    public boolean gameInProgress() {
+        return boardHasFreeSpace() && noWinnerYet();
+    }
+
+
+    int getCurrentPlayerIndex() {
+        return currentPlayerIndex;
+    }
+
     private void togglePlayer() {
         currentPlayerIndex =
                 currentPlayerIndex == PLAYER_ONE_INDEX
                         ? PLAYER_TWO_INDEX
                         : PLAYER_ONE_INDEX;
-    }
-
-
-    @Override
-    public boolean gameInProgress() {
-        return boardHasFreeSpace() && !hasWinner();
-    }
-
-    int getCurrentPlayerIndex() {
-        return currentPlayerIndex;
     }
 }

--- a/src/main/java/ttt/gui/TicTacToeRulesSpy.java
+++ b/src/main/java/ttt/gui/TicTacToeRulesSpy.java
@@ -51,6 +51,11 @@ public class TicTacToeRulesSpy implements GameRules {
     }
 
     @Override
+    public boolean noWinnerYet() {
+        return !hasWinner();
+    }
+
+    @Override
     public void initialiseGame(GameType gameType, String dimension) {
         if (board == null) {
             board = new Board(Integer.valueOf(dimension));

--- a/src/test/java/ttt/BoardFactoryStub.java
+++ b/src/test/java/ttt/BoardFactoryStub.java
@@ -22,7 +22,4 @@ public class BoardFactoryStub extends BoardFactory {
         }
     }
 
-    public Board getLatestBoard() {
-        return boards[boardIndex - 1];
-    }
 }

--- a/src/test/java/ttt/CommandLineGameControllerTest.java
+++ b/src/test/java/ttt/CommandLineGameControllerTest.java
@@ -114,7 +114,7 @@ public class CommandLineGameControllerTest {
                 gamePrompt
         );
 
-        commandLineGameController.displayResultsOfGame();
+        commandLineGameController.printExitMessage();
 
         assertThat(gamePrompt.getNumberOfTimesXHasWon(), is(1));
         assertThat(gamePrompt.getNumberOfTimesOHasWon(), is(0));
@@ -136,7 +136,7 @@ public class CommandLineGameControllerTest {
                 gamePrompt
         );
 
-        commandLineGameController.displayResultsOfGame();
+        commandLineGameController.printExitMessage();
 
         assertThat(gamePrompt.getNumberOfTimesDrawMessageHasBeenPrinted(), is(1));
         assertThat(gamePrompt.getLastBoardThatWasPrinted(), is("XOXOOXOXO"));

--- a/src/test/java/ttt/gui/TicTacToeRulesTest.java
+++ b/src/test/java/ttt/gui/TicTacToeRulesTest.java
@@ -21,14 +21,13 @@ import static ttt.player.PlayerSymbol.*;
 
 public class TicTacToeRulesTest {
     private static final Prompt UNUSED_PROMPT = null;
-    private Player[] players = new CommandLinePlayerFactory(UNUSED_PROMPT).createPlayers(HUMAN_VS_HUMAN, 3);
     private Board board = new Board(3);
+    private Player[] players = new CommandLinePlayerFactory(UNUSED_PROMPT).createPlayers(HUMAN_VS_HUMAN, 3);
 
     @Test
     public void makesMove() {
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(board, players);
+        TicTacToeRules ticTacToeRules = initialiseRules(board, players);
         int firstPlayer = ticTacToeRules.getCurrentPlayerIndex();
-
         ticTacToeRules.takeTurn(1);
 
         assertThat(board.getSymbolAt(1), is(X));
@@ -37,7 +36,7 @@ public class TicTacToeRulesTest {
 
     @Test
     public void hasWinner() {
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+        TicTacToeRules ticTacToeRules = initialiseRules(
                 new Board(
                         X, O, X,
                         O, X, O,
@@ -46,11 +45,12 @@ public class TicTacToeRulesTest {
                 players);
 
         assertThat(ticTacToeRules.hasWinner(), is(true));
+        assertThat(ticTacToeRules.noWinnerYet(), is(false));
     }
 
     @Test
     public void hasNoWinner() {
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+        TicTacToeRules ticTacToeRules = initialiseRules(
                 new Board(
                         X, O, X,
                         O, O, X,
@@ -58,13 +58,14 @@ public class TicTacToeRulesTest {
                 ),
                 players
         );
+        assertThat(ticTacToeRules.noWinnerYet(), is(true));
         assertThat(ticTacToeRules.hasWinner(), is(false));
     }
 
     @Test
     public void gameTypeIsSet() {
         CommandLinePlayerFactorySpy playerFactorySpy = new CommandLinePlayerFactorySpy();
-        TicTacToeRules gamesRules = new TicTacToeRules(new BoardFactory(), playerFactorySpy);
+        TicTacToeRules gamesRules = initialiseRulesWithFactories(new BoardFactory(), playerFactorySpy);
 
         gamesRules.initialiseGame(HUMAN_VS_HUMAN, "3");
 
@@ -73,28 +74,24 @@ public class TicTacToeRulesTest {
 
     @Test
     public void initialisesGame() {
-        Board board = new Board(3);
-
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+        TicTacToeRules ticTacToeRules = initialiseRulesWithFactories(
                 new BoardFactoryStub(board),
                 new CommandLinePlayerFactoryStub(players)
         );
+
         ticTacToeRules.initialiseGame(HUMAN_VS_HUMAN, "3");
 
         assertThat(ticTacToeRules.getBoard(), is(board));
     }
 
     @Test
-    public void currentPlayerReinitialisedWhenNewGameStarted(){
-        Board board = new Board(3);
-
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+    public void currentPlayerReinitialisedWhenNewGameStarted() {
+        TicTacToeRules ticTacToeRules = initialiseRulesWithFactories(
                 new BoardFactoryStub(board, board),
                 new CommandLinePlayerFactoryStub(players)
         );
 
-        ticTacToeRules.initialiseGame(HUMAN_VS_HUMAN, "3");
-        ticTacToeRules.takeTurn(1);
+        intialiseGameAndTogglePlayer(ticTacToeRules);
         ticTacToeRules.initialiseGame(HUMAN_VS_UNBEATABLE, "3");
 
         assertThat(ticTacToeRules.getCurrentPlayerIndex(), is(0));
@@ -107,15 +104,19 @@ public class TicTacToeRulesTest {
                 O, X, O,
                 VACANT, VACANT, X
         );
+        TicTacToeRules ticTacToeRules = initialiseRulesWithFactories(
+                new BoardFactoryStub(board),
+                new CommandLinePlayerFactory(UNUSED_PROMPT)
+        );
 
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(new BoardFactoryStub(board), new CommandLinePlayerFactory(UNUSED_PROMPT));
         ticTacToeRules.initialiseGame(HUMAN_VS_HUMAN, "3");
+
         assertThat(ticTacToeRules.getBoard(), is(board));
     }
 
     @Test
     public void gameInProgressWhenBoardHasFreeSpace() {
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+        TicTacToeRules ticTacToeRules = initialiseRules(
                 new Board(
                         X, O, X,
                         O, X, O,
@@ -129,7 +130,7 @@ public class TicTacToeRulesTest {
 
     @Test
     public void gameInProgressWhenBoardHasNoFreeSpace() {
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+        TicTacToeRules ticTacToeRules = initialiseRules(
                 new Board(
                         X, O, X,
                         O, X, O,
@@ -142,7 +143,7 @@ public class TicTacToeRulesTest {
 
     @Test
     public void gameInProgressWhenThereIsNoWinner() {
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+        TicTacToeRules ticTacToeRules = initialiseRules(
                 new Board(
                         VACANT, O, X,
                         O, X, O,
@@ -155,7 +156,7 @@ public class TicTacToeRulesTest {
 
     @Test
     public void gameNotInProgressWhenThereIsAWinner() {
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+        TicTacToeRules ticTacToeRules = initialiseRules(
                 new Board(
                         X, O, X,
                         O, O, X,
@@ -166,16 +167,36 @@ public class TicTacToeRulesTest {
         assertThat(ticTacToeRules.gameInProgress(), is(false));
     }
 
-
     @Test
     public void getCurrentPlayersNextMove() {
         PromptSpy promptSpy = new PromptSpy(new StringReader("1"));
-        players = new CommandLinePlayerFactory(promptSpy).createPlayers(HUMAN_VS_HUMAN, 3);
-        TicTacToeRules gamesRules = new TicTacToeRules(board, players);
+        TicTacToeRules gamesRules = initialiseRules(
+                board,
+                new CommandLinePlayerFactory(promptSpy).createPlayers(HUMAN_VS_HUMAN, 3)
+        );
 
         int move = gamesRules.getCurrentPlayersNextMove();
 
         assertThat(move, is(1));
+    }
+
+    private TicTacToeRules initialiseRulesWithFactories(BoardFactory boardFactory, CommandLinePlayerFactory playerFactory) {
+        return new TicTacToeRules(
+                boardFactory,
+                playerFactory
+        );
+    }
+
+    private TicTacToeRules initialiseRules(Board board, Player[] players) {
+        return new TicTacToeRules(
+                board,
+                players
+        );
+    }
+
+    private void intialiseGameAndTogglePlayer(TicTacToeRules ticTacToeRules) {
+        ticTacToeRules.initialiseGame(HUMAN_VS_HUMAN, "3");
+        ticTacToeRules.takeTurn(1);
     }
 }
 

--- a/src/test/java/ttt/gui/TicTacToeRulesTest.java
+++ b/src/test/java/ttt/gui/TicTacToeRulesTest.java
@@ -6,15 +6,17 @@ import ttt.CommandLinePlayerFactoryStub;
 import ttt.PromptSpy;
 import ttt.board.Board;
 import ttt.board.BoardFactory;
-import ttt.player.Player;
 import ttt.player.CommandLinePlayerFactory;
+import ttt.player.Player;
 import ttt.ui.Prompt;
 
 import java.io.StringReader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static ttt.GameType.HUMAN_VS_HUMAN;
+import static ttt.GameType.HUMAN_VS_UNBEATABLE;
 import static ttt.player.PlayerSymbol.*;
 
 public class TicTacToeRulesTest {
@@ -78,7 +80,24 @@ public class TicTacToeRulesTest {
                 new CommandLinePlayerFactoryStub(players)
         );
         ticTacToeRules.initialiseGame(HUMAN_VS_HUMAN, "3");
+
         assertThat(ticTacToeRules.getBoard(), is(board));
+    }
+
+    @Test
+    public void currentPlayerReinitialisedWhenNewGameStarted(){
+        Board board = new Board(3);
+
+        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+                new BoardFactoryStub(board, board),
+                new CommandLinePlayerFactoryStub(players)
+        );
+
+        ticTacToeRules.initialiseGame(HUMAN_VS_HUMAN, "3");
+        ticTacToeRules.takeTurn(1);
+        ticTacToeRules.initialiseGame(HUMAN_VS_UNBEATABLE, "3");
+
+        assertThat(ticTacToeRules.getCurrentPlayerIndex(), is(0));
     }
 
     @Test


### PR DESCRIPTION
@jsuchy @ecomba

During the IPM @ecomba spotted a bug during the demo.

When replaying, and switching from an Unbeatable vs Human game to Human vs Unbeatable, the computer player was (incorrectly) taking the first go.

This fixes the problem. When the game is initialised, the currentPlayerIndex needs re-initialising to 0. This way the correct player (the human) is picked up.
