### PR TITLE
Observer pattern for guiplayer

### DIFF
--- a/src/main/java/ttt/gui/GameController.java
+++ b/src/main/java/ttt/gui/GameController.java
@@ -6,7 +6,7 @@ import ttt.player.Player;
 public interface GameController {
     void presentGameTypes();
     void presentBoardDimensionsFor(GameType gameType);
-    void presentBoard(int dimension);
-    void playMove(int position);
+    void startGame(int dimension);
+    void takeMove(int position);
     Player getCurrentPlayer();
 }

--- a/src/main/java/ttt/gui/GameController.java
+++ b/src/main/java/ttt/gui/GameController.java
@@ -1,10 +1,12 @@
 package ttt.gui;
 
 import ttt.GameType;
+import ttt.player.Player;
 
 public interface GameController {
     void presentGameTypes();
     void presentBoardDimensionsFor(GameType gameType);
     void presentBoard(int dimension);
     void playMove(int position);
+    Player getCurrentPlayer();
 }

--- a/src/main/java/ttt/gui/GameRules.java
+++ b/src/main/java/ttt/gui/GameRules.java
@@ -7,11 +7,11 @@ import ttt.player.PlayerSymbol;
 
 public interface GameRules {
     void initialiseGame(GameType gameType, int dimension);
-    PlayerSymbol getWinningSymbol();
+    void playGame();
     boolean hasWinner();
     boolean noWinnerYet();
+    PlayerSymbol getWinningSymbol();
     Board getBoard();
     boolean hasAvailableMoves();
-    void playGame();
     Player getCurrentPlayer();
 }

--- a/src/main/java/ttt/gui/GuiGameController.java
+++ b/src/main/java/ttt/gui/GuiGameController.java
@@ -32,19 +32,15 @@ public class GuiGameController implements GameController {
     }
 
     @Override
-    public void presentBoard(int dimension) {
+    public void startGame(int dimension) {
         ticTacToeRules.initialiseGame(gameType, dimension);
-        Board board = ticTacToeRules.getBoard();
-        ticTacToeRules.playGame();
-        printBoard(board);
+        playTurns();
     }
 
     @Override
-    public void playMove(int position) {
-        ticTacToeRules.playGame();
-        Board latestBoard = ticTacToeRules.getBoard();
-        printBoard(latestBoard);
-        displayExitMessage(latestBoard);
+    public void takeMove(int position) {
+        playTurns();
+        displayExitMessage(ticTacToeRules.getBoard());
     }
 
     @Override
@@ -52,16 +48,18 @@ public class GuiGameController implements GameController {
         return ticTacToeRules.getCurrentPlayer();
     }
 
-    private void printBoard(Board board) {
-        boardView.presentsBoard(board);
-    }
-
-    public void setGameType(GameType gameType) {
+    void setGameType(GameType gameType) {
         this.gameType = gameType;
     }
 
     GameType getGameType() {
         return gameType;
+    }
+
+    private void playTurns() {
+        ticTacToeRules.playGame();
+        Board board = ticTacToeRules.getBoard();
+        boardView.presentsBoard(board);
     }
 
     private void displayExitMessage(Board board) {

--- a/src/main/java/ttt/gui/GuiGameController.java
+++ b/src/main/java/ttt/gui/GuiGameController.java
@@ -56,7 +56,7 @@ public class GuiGameController implements GameController {
 
     private void preloadHumanWithMoveAt(int position) {
         Player currentPlayer = ticTacToeRules.getCurrentPlayer();
-        ((GuiHumanPlayer)currentPlayer).setMove(Integer.valueOf(position));
+        ((GuiHumanPlayer)currentPlayer).update(Integer.valueOf(position));
     }
 
     public void setGameType(GameType gameType) {

--- a/src/main/java/ttt/gui/GuiGameController.java
+++ b/src/main/java/ttt/gui/GuiGameController.java
@@ -55,8 +55,12 @@ public class GuiGameController implements GameController {
     }
 
     private void preloadHumanWithMoveAt(int position) {
-        Player currentPlayer = ticTacToeRules.getCurrentPlayer();
+        Player currentPlayer = getCurrentPlayer();
         ((GuiHumanPlayer)currentPlayer).update(Integer.valueOf(position));
+    }
+
+    private Player getCurrentPlayer() {
+        return ticTacToeRules.getCurrentPlayer();
     }
 
     public void setGameType(GameType gameType) {

--- a/src/main/java/ttt/gui/GuiGameController.java
+++ b/src/main/java/ttt/gui/GuiGameController.java
@@ -48,7 +48,6 @@ public class GuiGameController implements GameController {
         return ticTacToeRules.getCurrentPlayer();
     }
 
-
     void setGameType(GameType gameType) {
         this.gameType = gameType;
     }

--- a/src/main/java/ttt/gui/GuiGameController.java
+++ b/src/main/java/ttt/gui/GuiGameController.java
@@ -2,7 +2,6 @@ package ttt.gui;
 
 import ttt.GameType;
 import ttt.board.Board;
-import ttt.player.GuiHumanPlayer;
 import ttt.player.Player;
 
 import java.util.List;
@@ -42,25 +41,19 @@ public class GuiGameController implements GameController {
 
     @Override
     public void playMove(int position) {
-        preloadHumanWithMoveAt(position);
-
         ticTacToeRules.playGame();
         Board latestBoard = ticTacToeRules.getBoard();
         printBoard(latestBoard);
         displayExitMessage(latestBoard);
     }
 
+    @Override
+    public Player getCurrentPlayer() {
+        return ticTacToeRules.getCurrentPlayer();
+    }
+
     private void printBoard(Board board) {
         boardView.presentsBoard(board);
-    }
-
-    private void preloadHumanWithMoveAt(int position) {
-        Player currentPlayer = getCurrentPlayer();
-        ((GuiHumanPlayer)currentPlayer).update(Integer.valueOf(position));
-    }
-
-    private Player getCurrentPlayer() {
-        return ticTacToeRules.getCurrentPlayer();
     }
 
     public void setGameType(GameType gameType) {

--- a/src/main/java/ttt/gui/GuiGameController.java
+++ b/src/main/java/ttt/gui/GuiGameController.java
@@ -48,6 +48,7 @@ public class GuiGameController implements GameController {
         return ticTacToeRules.getCurrentPlayer();
     }
 
+
     void setGameType(GameType gameType) {
         this.gameType = gameType;
     }

--- a/src/main/java/ttt/gui/MovePublisher.java
+++ b/src/main/java/ttt/gui/MovePublisher.java
@@ -1,0 +1,5 @@
+package ttt.gui;
+
+public interface MovePublisher {
+    void notifyObserver(int indexOfMove);
+}

--- a/src/main/java/ttt/gui/MovePublisher.java
+++ b/src/main/java/ttt/gui/MovePublisher.java
@@ -1,5 +1,8 @@
 package ttt.gui;
 
+import ttt.player.Player;
+
 public interface MovePublisher {
     void notifyObserver(int indexOfMove);
+    void register(Player player);
 }

--- a/src/main/java/ttt/gui/TicTacToeBoardPresenter.java
+++ b/src/main/java/ttt/gui/TicTacToeBoardPresenter.java
@@ -258,8 +258,7 @@ public class TicTacToeBoardPresenter implements DisplayPresenter {
             disableOccupied(button);
 
             DeactivatableElement clickableCell = new JavaFxButton(button);
-            UserSelectsButtonForMove makeMoveOnClick = new UserSelectsButtonForMove(controller, clickableCell);
-            makeMoveOnClick.register(controller.getCurrentPlayer());
+            ClickEvent makeMoveOnClick = new UserSelectsButtonForMove(controller, clickableCell);
             registerClickEvent.register(clickableCell, makeMoveOnClick);
             return null;
         };

--- a/src/main/java/ttt/gui/TicTacToeBoardPresenter.java
+++ b/src/main/java/ttt/gui/TicTacToeBoardPresenter.java
@@ -258,7 +258,8 @@ public class TicTacToeBoardPresenter implements DisplayPresenter {
             disableOccupied(button);
 
             DeactivatableElement clickableCell = new JavaFxButton(button);
-            ClickEvent makeMoveOnClick = new UserSelectsButtonForMove(controller, clickableCell);
+            UserSelectsButtonForMove makeMoveOnClick = new UserSelectsButtonForMove(controller, clickableCell);
+            makeMoveOnClick.register(controller.getCurrentPlayer());
             registerClickEvent.register(clickableCell, makeMoveOnClick);
             return null;
         };

--- a/src/main/java/ttt/gui/TicTacToeRules.java
+++ b/src/main/java/ttt/gui/TicTacToeRules.java
@@ -43,6 +43,16 @@ public class TicTacToeRules implements GameRules {
     }
 
     @Override
+    public boolean hasWinner() {
+        return board.hasWinningCombination();
+    }
+
+    @Override
+    public boolean noWinnerYet() {
+        return !hasWinner();
+    }
+
+    @Override
     public PlayerSymbol getWinningSymbol() {
         return board.getWinningSymbol();
     }
@@ -55,16 +65,6 @@ public class TicTacToeRules implements GameRules {
     @Override
     public boolean hasAvailableMoves() {
         return board.hasFreeSpace();
-    }
-
-    @Override
-    public boolean hasWinner() {
-        return board.hasWinningCombination();
-    }
-
-    @Override
-    public boolean noWinnerYet() {
-        return !hasWinner();
     }
 
     @Override

--- a/src/main/java/ttt/gui/UserSelectsBoardDimension.java
+++ b/src/main/java/ttt/gui/UserSelectsBoardDimension.java
@@ -11,6 +11,6 @@ public class UserSelectsBoardDimension implements ClickEvent {
 
     @Override
     public void action() {
-        controller.presentBoard(Integer.valueOf(dimensionSelectionButton.getText()));
+        controller.startGame(Integer.valueOf(dimensionSelectionButton.getText()));
     }
 }

--- a/src/main/java/ttt/gui/UserSelectsButtonForMove.java
+++ b/src/main/java/ttt/gui/UserSelectsButtonForMove.java
@@ -1,8 +1,12 @@
 package ttt.gui;
 
-public class UserSelectsButtonForMove implements ClickEvent {
+import ttt.player.GuiHumanPlayer;
+import ttt.player.Player;
+
+public class UserSelectsButtonForMove implements ClickEvent, MovePublisher {
     private GameController controller;
     private DeactivatableElement deactivatableElement;
+    private Player observer;
 
     public UserSelectsButtonForMove(GameController controller, DeactivatableElement deactivatableElement) {
         this.controller = controller;
@@ -11,6 +15,21 @@ public class UserSelectsButtonForMove implements ClickEvent {
 
     @Override
     public void action() {
-        controller.playMove(Integer.valueOf(deactivatableElement.getId()));
+        int position = Integer.valueOf(deactivatableElement.getId());
+        notifyObserver(position);
+        controller.playMove(position);
+    }
+
+    @Override
+    public void notifyObserver(int indexOfMove) {
+        ((GuiHumanPlayer)observer).update(indexOfMove);
+    }
+
+    public void register(Player player) {
+        this.observer = player;
+    }
+
+    public Player getObserver() {
+        return observer;
     }
 }

--- a/src/main/java/ttt/gui/UserSelectsButtonForMove.java
+++ b/src/main/java/ttt/gui/UserSelectsButtonForMove.java
@@ -11,13 +11,14 @@ public class UserSelectsButtonForMove implements ClickEvent, MovePublisher {
     public UserSelectsButtonForMove(GameController controller, DeactivatableElement deactivatableElement) {
         this.controller = controller;
         this.deactivatableElement = deactivatableElement;
+        register(controller.getCurrentPlayer());
     }
 
     @Override
     public void action() {
         int position = Integer.valueOf(deactivatableElement.getId());
         notifyObserver(position);
-        controller.playMove(position);
+        controller.takeMove(position);
     }
 
     @Override

--- a/src/main/java/ttt/gui/UserSelectsButtonForMove.java
+++ b/src/main/java/ttt/gui/UserSelectsButtonForMove.java
@@ -1,6 +1,6 @@
 package ttt.gui;
 
-import ttt.player.GuiHumanPlayer;
+import ttt.player.MoveObserver;
 import ttt.player.Player;
 
 public class UserSelectsButtonForMove implements ClickEvent, MovePublisher {
@@ -23,9 +23,10 @@ public class UserSelectsButtonForMove implements ClickEvent, MovePublisher {
 
     @Override
     public void notifyObserver(int indexOfMove) {
-        ((GuiHumanPlayer)observer).update(indexOfMove);
+        ((MoveObserver)observer).update(indexOfMove);
     }
 
+    @Override
     public void register(Player player) {
         this.observer = player;
     }

--- a/src/main/java/ttt/player/ConfigurableMovePlayer.java
+++ b/src/main/java/ttt/player/ConfigurableMovePlayer.java
@@ -1,5 +1,0 @@
-package ttt.player;
-
-public interface ConfigurableMovePlayer {
-    void setMove(int moveFromGui);
-}

--- a/src/main/java/ttt/player/GuiHumanPlayer.java
+++ b/src/main/java/ttt/player/GuiHumanPlayer.java
@@ -2,7 +2,7 @@ package ttt.player;
 
 import ttt.board.Board;
 
-public class GuiHumanPlayer extends Player implements ConfigurableMovePlayer {
+public class GuiHumanPlayer extends Player implements MoveObserver {
     private static final int UNSET_MOVE = -1;
     private int moveFromGui = UNSET_MOVE;
 
@@ -23,7 +23,7 @@ public class GuiHumanPlayer extends Player implements ConfigurableMovePlayer {
     }
 
     @Override
-    public void setMove(int moveFromGui) {
+    public void update(int moveFromGui) {
         this.moveFromGui = moveFromGui;
     }
 }

--- a/src/main/java/ttt/player/MoveObserver.java
+++ b/src/main/java/ttt/player/MoveObserver.java
@@ -1,0 +1,5 @@
+package ttt.player;
+
+public interface MoveObserver {
+    void update(int moveFromGui);
+}

--- a/src/test/java/ttt/gui/GuiGameControllerSpy.java
+++ b/src/test/java/ttt/gui/GuiGameControllerSpy.java
@@ -23,13 +23,13 @@ public class GuiGameControllerSpy implements GameController {
     }
 
     @Override
-    public void presentBoard(int dimensionForBoard) {
+    public void startGame(int dimensionForBoard) {
         hasPresentedBoard = true;
         boardDimension = Integer.valueOf(dimensionForBoard);
     }
 
     @Override
-    public void playMove(int position) {
+    public void takeMove(int position) {
         hasTakenMove = true;
     }
 

--- a/src/test/java/ttt/gui/GuiGameControllerSpy.java
+++ b/src/test/java/ttt/gui/GuiGameControllerSpy.java
@@ -1,6 +1,7 @@
 package ttt.gui;
 
 import ttt.GameType;
+import ttt.player.Player;
 
 public class GuiGameControllerSpy implements GameController {
     private boolean hasPresentedBoardDimensions = false;
@@ -30,6 +31,11 @@ public class GuiGameControllerSpy implements GameController {
     @Override
     public void playMove(int position) {
         hasTakenMove = true;
+    }
+
+    @Override
+    public Player getCurrentPlayer() {
+        return null;
     }
 
     public boolean hasPresentedGameTypes() {

--- a/src/test/java/ttt/gui/GuiGameControllerTest.java
+++ b/src/test/java/ttt/gui/GuiGameControllerTest.java
@@ -63,8 +63,8 @@ public class GuiGameControllerTest {
 
         controller.playMove(1);
 
-        assertThat(gameRulesSpy.hasGotCurrentPlayer(), is(true));
-        assertThat(guiHumanPlayer.hasBeenPreloadedWithMove(), is(true));
+        assertThat(gameRulesSpy.hasGotCurrentPlayer(), is(false));
+        assertThat(guiHumanPlayer.hasBeenPreloadedWithMove(), is(false));
         assertThat(gameRulesSpy.hasGameBeenPlayed(), is(true));
         assertThat(boardPresenterSpy.hasDrawnBoard(), is(true));
     }
@@ -79,7 +79,7 @@ public class GuiGameControllerTest {
         gameRulesSpy = new TicTacToeRulesSpy(winningBoard);
         GuiGameController controller = new GuiGameController(gameConfigurationSpy, gameRulesSpy, createViewFactory());
 
-        controller.playMove(-1);
+        controller.playMove(1);
 
         assertThat(gameRulesSpy.gameCheckedForWin(), is(true));
         assertThat(gameRulesSpy.hasGotWinnersSymbol(), is(true));
@@ -97,7 +97,7 @@ public class GuiGameControllerTest {
         gameRulesSpy = new TicTacToeRulesSpy(drawnBoard);
         GuiGameController controller = new GuiGameController(gameConfigurationSpy, gameRulesSpy, createViewFactory());
 
-        controller.playMove(-1);
+        controller.playMove(1);
 
         assertThat(gameRulesSpy.hasGameBeenPlayed(), is(true));
         assertThat(gameRulesSpy.numberOfTimesBoardIsObtained(), is(1));
@@ -114,7 +114,7 @@ public class GuiGameControllerTest {
         gameRulesSpy = new TicTacToeRulesSpy(winningBoard);
         GuiGameController controller = new GuiGameController(gameConfigurationSpy, gameRulesSpy, createViewFactory());
 
-        controller.playMove(6);
+        controller.playMove(1);
 
         assertThat(gameRulesSpy.gameCheckedForWin(), is(true));
         assertThat(gameRulesSpy.hasGotWinnersSymbol(), is(true));

--- a/src/test/java/ttt/gui/GuiGameControllerTest.java
+++ b/src/test/java/ttt/gui/GuiGameControllerTest.java
@@ -40,7 +40,7 @@ public class GuiGameControllerTest {
         GuiGameController controller = new GuiGameController(humanVsHumanGameConfiguration, gameRulesSpy, createViewFactory());
         controller.setGameType(HUMAN_VS_HUMAN);
 
-        controller.presentBoard(3);
+        controller.startGame(3);
 
         assertThat(gameRulesSpy.hasInitialisedGame(), is(true));
         assertThat(gameRulesSpy.hasGameBeenPlayed(), is(true));
@@ -61,7 +61,7 @@ public class GuiGameControllerTest {
         gameRulesSpy = new TicTacToeRulesSpy(new Board(3), guiHumanPlayer);
         GuiGameController controller = new GuiGameController(gameConfigurationSpy, gameRulesSpy, createViewFactory());
 
-        controller.playMove(1);
+        controller.takeMove(1);
 
         assertThat(gameRulesSpy.hasGotCurrentPlayer(), is(false));
         assertThat(guiHumanPlayer.hasBeenPreloadedWithMove(), is(false));
@@ -79,7 +79,7 @@ public class GuiGameControllerTest {
         gameRulesSpy = new TicTacToeRulesSpy(winningBoard);
         GuiGameController controller = new GuiGameController(gameConfigurationSpy, gameRulesSpy, createViewFactory());
 
-        controller.playMove(1);
+        controller.takeMove(1);
 
         assertThat(gameRulesSpy.gameCheckedForWin(), is(true));
         assertThat(gameRulesSpy.hasGotWinnersSymbol(), is(true));
@@ -97,10 +97,10 @@ public class GuiGameControllerTest {
         gameRulesSpy = new TicTacToeRulesSpy(drawnBoard);
         GuiGameController controller = new GuiGameController(gameConfigurationSpy, gameRulesSpy, createViewFactory());
 
-        controller.playMove(1);
+        controller.takeMove(1);
 
         assertThat(gameRulesSpy.hasGameBeenPlayed(), is(true));
-        assertThat(gameRulesSpy.numberOfTimesBoardIsObtained(), is(1));
+        assertThat(gameRulesSpy.numberOfTimesBoardIsObtained(), is(2));
         assertThat(boardPresenterSpy.hasIdentifiedADraw(), is(true));
     }
 
@@ -114,7 +114,7 @@ public class GuiGameControllerTest {
         gameRulesSpy = new TicTacToeRulesSpy(winningBoard);
         GuiGameController controller = new GuiGameController(gameConfigurationSpy, gameRulesSpy, createViewFactory());
 
-        controller.playMove(1);
+        controller.takeMove(1);
 
         assertThat(gameRulesSpy.gameCheckedForWin(), is(true));
         assertThat(gameRulesSpy.hasGotWinnersSymbol(), is(true));

--- a/src/test/java/ttt/gui/GuiHumanPlayerSpy.java
+++ b/src/test/java/ttt/gui/GuiHumanPlayerSpy.java
@@ -10,7 +10,7 @@ public class GuiHumanPlayerSpy extends GuiHumanPlayer {
         super(symbol);
     }
 
-    public void setMove(int move) {
+    public void update(int move) {
         preloadedWithMove = true;
     }
 

--- a/src/test/java/ttt/gui/TicTacToeRulesTest.java
+++ b/src/test/java/ttt/gui/TicTacToeRulesTest.java
@@ -78,7 +78,7 @@ public class TicTacToeRulesTest {
     public void currentPlayerReinitialisedWhenNewGameStarted() {
         TicTacToeRules ticTacToeRules = initialiseRulesWithFactories(
                 new BoardFactoryStub(board, board),
-                new CommandLinePlayerFactoryStub(new FakePlayer(X, 0, 1, 2), new FakePlayer(O, 3, 4))
+                new CommandLinePlayerFactoryStub(new Player[] {new FakePlayer(X, 0, 1, 2), new FakePlayer(O, 3, 4)})
         );
 
         ticTacToeRules.initialiseGame(HUMAN_VS_HUMAN, 3);

--- a/src/test/java/ttt/gui/TicTacToeRulesTest.java
+++ b/src/test/java/ttt/gui/TicTacToeRulesTest.java
@@ -78,7 +78,7 @@ public class TicTacToeRulesTest {
     public void currentPlayerReinitialisedWhenNewGameStarted() {
         TicTacToeRules ticTacToeRules = initialiseRulesWithFactories(
                 new BoardFactoryStub(board, board),
-                new CommandLinePlayerFactoryStub(new Player[] {new FakePlayer(X, 0, 1, 2), new FakePlayer(O, 3, 4)})
+                new CommandLinePlayerFactoryStub(new FakePlayer(X, 0, 1, 2), new FakePlayer(O, 3, 4))
         );
 
         ticTacToeRules.initialiseGame(HUMAN_VS_HUMAN, 3);

--- a/src/test/java/ttt/gui/TicTacToeRulesTest.java
+++ b/src/test/java/ttt/gui/TicTacToeRulesTest.java
@@ -78,7 +78,7 @@ public class TicTacToeRulesTest {
     public void currentPlayerReinitialisedWhenNewGameStarted() {
         TicTacToeRules ticTacToeRules = initialiseRulesWithFactories(
                 new BoardFactoryStub(board, board),
-                new CommandLinePlayerFactoryStub(new Player[] {new FakePlayer(X, 0, 1, 2), new FakePlayer(O, 3, 4)})
+                new CommandLinePlayerFactoryStub(new FakePlayer(X, 0, 1, 2), new FakePlayer(O, 3, 4))
         );
 
         ticTacToeRules.initialiseGame(HUMAN_VS_HUMAN, 3);
@@ -160,8 +160,10 @@ public class TicTacToeRulesTest {
 
     @Test
     public void gameLoopsUntilThereIsAWinner() {
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(board, new Player[]{
-                new FakePlayer(X, 0, 1, 2), new FakePlayer(O, 3, 4)});
+        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+                board,
+                new Player[]{new FakePlayer(X, 0, 1, 2), new FakePlayer(O, 3, 4)}
+        );
 
         ticTacToeRules.playGame();
 
@@ -175,8 +177,10 @@ public class TicTacToeRulesTest {
 
     @Test
     public void gameLoopsUntilNoSpaceOnBoard() {
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(board, new Player[]{
-                new FakePlayer(X, 0, 2, 4, 5, 7), new FakePlayer(O, 1, 3, 6, 8)});
+        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+                board,
+                new Player[]{new FakePlayer(X, 0, 2, 4, 5, 7), new FakePlayer(O, 1, 3, 6, 8)}
+        );
 
         ticTacToeRules.playGame();
 
@@ -196,9 +200,10 @@ public class TicTacToeRulesTest {
     public void gameLoopsUntilPlayerIsNotReady() {
         GuiHumanPlayer testPlayer = new GuiHumanPlayer(X);
         testPlayer.update(0);
-        FakePlayer fakePlayer = new FakePlayer(O, 3, 7);
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(board, new Player[]{
-                testPlayer, fakePlayer});
+        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+                board,
+                new Player[]{testPlayer, new FakePlayer(O, 3, 7)}
+        );
 
         ticTacToeRules.playGame();
 
@@ -209,10 +214,10 @@ public class TicTacToeRulesTest {
 
     @Test
     public void getCurrentPlayer() {
-        GuiHumanPlayer testPlayer = new GuiHumanPlayer(X);
-        FakePlayer fakePlayer = new FakePlayer(O);
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(board, new Player[]{
-                testPlayer, fakePlayer});
+        TicTacToeRules ticTacToeRules = new TicTacToeRules(
+                board,
+                new Player[]{new GuiHumanPlayer(X), new FakePlayer(O)}
+        );
 
         Player currentPlayer = ticTacToeRules.getCurrentPlayer();
 

--- a/src/test/java/ttt/gui/TicTacToeRulesTest.java
+++ b/src/test/java/ttt/gui/TicTacToeRulesTest.java
@@ -195,7 +195,7 @@ public class TicTacToeRulesTest {
     @Test
     public void gameLoopsUntilPlayerIsNotReady() {
         GuiHumanPlayer testPlayer = new GuiHumanPlayer(X);
-        testPlayer.setMove(0);
+        testPlayer.update(0);
         FakePlayer fakePlayer = new FakePlayer(O, 3, 7);
         TicTacToeRules ticTacToeRules = new TicTacToeRules(board, new Player[]{
                 testPlayer, fakePlayer});

--- a/src/test/java/ttt/gui/UserSelectsButtonForMoveTest.java
+++ b/src/test/java/ttt/gui/UserSelectsButtonForMoveTest.java
@@ -1,20 +1,43 @@
 package ttt.gui;
 
+import org.junit.Before;
 import org.junit.Test;
+import ttt.player.GuiHumanPlayer;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static ttt.player.PlayerSymbol.X;
 
 public class UserSelectsButtonForMoveTest {
 
+    private UserSelectsButtonForMove userSelectsButtonForMoveWithObserver;
+    private GuiGameControllerSpy controller = new GuiGameControllerSpy();
+    private DeactivableElementSpy button = new DeactivableElementSpy();
+    private GuiHumanPlayer observingPlayer = new GuiHumanPlayer(X);
+
+    @Before
+    public void setup() {
+        userSelectsButtonForMoveWithObserver = new UserSelectsButtonForMove(controller, button);
+        userSelectsButtonForMoveWithObserver.register(observingPlayer);
+    }
+
     @Test
     public void userMakesAMove() {
-        GuiGameControllerSpy controller = new GuiGameControllerSpy();
-        DeactivableElementSpy button = new DeactivableElementSpy();
-        UserSelectsButtonForMove userSelectsButtonForMove = new UserSelectsButtonForMove(controller, button);
-        userSelectsButtonForMove.action();
+        userSelectsButtonForMoveWithObserver.action();
 
         assertThat(controller.hasTakenMove(), is(true));
+    }
+
+    @Test
+    public void getsRegisteredObserver() {
+        assertThat(userSelectsButtonForMoveWithObserver.getObserver(), is(observingPlayer));
+    }
+
+    @Test
+    public void updateObserverOnAction() {
+        userSelectsButtonForMoveWithObserver.action();
+
+        assertThat(observingPlayer.isReady(), is(true));
     }
 
     private static class DeactivableElementSpy implements DeactivatableElement {

--- a/src/test/java/ttt/player/GuiHumanPlayerTest.java
+++ b/src/test/java/ttt/player/GuiHumanPlayerTest.java
@@ -12,7 +12,7 @@ public class GuiHumanPlayerTest {
     @Test
     public void playerIsReadyToMove() {
         GuiHumanPlayer guiHuman = new GuiHumanPlayer(X);
-        guiHuman.setMove(3);
+        guiHuman.update(3);
 
         assertThat(guiHuman.isReady(), is(true));
     }
@@ -28,7 +28,7 @@ public class GuiHumanPlayerTest {
     @Test
     public void onceMoveIsMadePlayerIsNotReady() {
         GuiHumanPlayer guiHuman = new GuiHumanPlayer(X);
-        guiHuman.setMove(4);
+        guiHuman.update(4);
 
         guiHuman.chooseNextMoveFrom(new Board(3));
 


### PR DESCRIPTION
@jsuchy, @ecomba This change is done on top of the pull request [#32](https://github.com/gemcfadyen/Apprenticeship-JavaTicTacToe/pull/32) to formalise the use of the Observer pattern. 

Pro's:
- There are no casts to GuiHumanPlayer outside of the `UserSelectsButtonForMove` class.
- The controller is unaware of what kind of player is taking a go, so as such all players are treated the same.
- The current player is obtained via the controller to stop the player being passed from the GuiGameController, into the presentsBoard method.
- Potentially more flexible if new game types were added. If a new game type which didn't involve a human player (such as unbeatable vs unbeatable) was added, the code to preload the human with the move would not be touched, as that listener would not be executed. Whereas in PR #32 the code is in the controller, so it would need updating.

Con's:
- The method 'getCurrentPlayer()' was introduced to the controller so that the current player can be obtained from within 'GuiGameController' . 
- The registration of the observer is 'hidden' in the constructor of the 'UserSelectsButtonForMove'. This is to prevent the registration happening in TicTacToeBoardPresenter (where I felt obtaining the current player was at a different level of abstraction from the rest of the logic).
