### PR TITLE
Reuses the logic in the gui application rather than duplicates it for gui end to end test

### DIFF
--- a/src/main/java/ttt/gui/JavaFxGui.java
+++ b/src/main/java/ttt/gui/JavaFxGui.java
@@ -21,7 +21,10 @@ public class JavaFxGui extends Application {
         primaryStage.setScene(scene);
         primaryStage.show();
 
+        playTicTacToe(scene);
+    }
 
+    void playTicTacToe(Scene scene) {
         GameRules ticTacToeRules = new TicTacToeRules(new BoardFactory(), new GuiPlayerFactory());
         GuiGameController guiGameController = new GuiGameController(
                 new TicTacToeGameConfiguration(),

--- a/src/test/java/ttt/gui/GameIsPlayedThroughTheGuiTest.java
+++ b/src/test/java/ttt/gui/GameIsPlayedThroughTheGuiTest.java
@@ -9,15 +9,13 @@ import javafx.scene.layout.GridPane;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import ttt.board.BoardFactory;
-import ttt.player.GuiPlayerFactory;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class GameIsPlayedThroughTheGuiTest {
     private Scene scene;
-    private GuiGameController controller;
+    private JavaFxGui gui;
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -27,17 +25,12 @@ public class GameIsPlayedThroughTheGuiTest {
     @Before
     public void setup() {
         scene = new Scene(new GridPane(), 700, 700);
-        TicTacToeRules ticTacToeRules = new TicTacToeRules(new BoardFactory(), new GuiPlayerFactory());
-        controller = new GuiGameController(
-                new TicTacToeGameConfiguration(),
-                ticTacToeRules,
-                new JavaFxViewFactory(scene)
-        );
+        gui = new JavaFxGui();
     }
 
     @Test
     public void playersTakeTurnsUntilGameIsWon() {
-        controller.presentGameTypes();
+        gui.playTicTacToe(scene);
 
         selectHumanVsHumanGameType(scene);
         select3x3Grid(scene);
@@ -53,7 +46,7 @@ public class GameIsPlayedThroughTheGuiTest {
 
     @Test
     public void playersTakeTurnsUntilGameIsDrawn() {
-        controller.presentGameTypes();
+        gui.playTicTacToe(scene);
 
         selectHumanVsHumanGameType(scene);
         select3x3Grid(scene);


### PR DESCRIPTION
@ecomba @jsuchy Small tidy up.

The gui end to end test duplicated the game setup logic found in the gui application. 

To remove this duplication, I have exposed the game setup, thus can call it from the end to end test.
This means that if the gui app is updated, there is not separate test logic to also update.
